### PR TITLE
Overloading __str__

### DIFF
--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -153,3 +153,6 @@ class RopChain(object):
         cp._rebase_val = self._rebase_val
 
         return cp
+
+    def __str__(self):
+        return self.payload_str()


### PR DESCRIPTION
Making it a bit easier to pull out the rop chain itself by overloading __str__.