### PR TITLE
Wip/dumb tracer

### DIFF
--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -31,7 +31,7 @@ class ChainBuilder(object):
         :param duplicates:
         :param reg_list: A list of multipurpose registers
         :param base_pointer: The name ("offset") for base pointer register
-        :param badbytes: A list with badbytes, which we should avaoid
+        :param badbytes: A list with badbytes, which we should avoid
         :param roparg_filler: An integer used when popping superfluous registers
         """
         self.project = project
@@ -75,7 +75,7 @@ class ChainBuilder(object):
         """
 
         if len(registers) == 0:
-            return RopChain(self.project, self, rebase=self._rebase)
+            return RopChain(self.project, self, rebase=self._rebase, badbytes=self.badbytes)
 
         if rebase_regs is None:
             rebase_regs = set()
@@ -261,7 +261,7 @@ class ChainBuilder(object):
         l.debug("Now building the mem write chain")
 
         # build the chain
-        chain = RopChain(self.project, self, rebase=self._rebase)
+        chain = RopChain(self.project, self, rebase=self._rebase, badbytes=self.badbytes)
         for i in range(0, len(string_data), bytes_per_write):
             to_write = string_data[i: i+bytes_per_write]
             # pad if needed
@@ -392,7 +392,7 @@ class ChainBuilder(object):
             final_value = 0
         else:
             raise Exception("This shouldn't happen")
-        chain = RopChain(self.project, self, rebase=self._rebase)
+        chain = RopChain(self.project, self, rebase=self._rebase, badbytes=self.badbytes)
         for i in range(0, len(data), bytes_per_write):
             chain = chain + self._change_mem_with_gadget(best_gadget, addr + i,
                                                          mem_change.data_size, final_val=final_value)
@@ -472,7 +472,7 @@ class ChainBuilder(object):
         if len(registers) > 0:
             chain = self.set_regs(use_partial_controllers=use_partial_controllers, **registers)
         else:
-            chain = RopChain(self.project, self, rebase=self._rebase)
+            chain = RopChain(self.project, self, rebase=self._rebase, badbytes=self.badbytes)
 
         # stack arguments
         bytes_per_arg = self.project.arch.bytes
@@ -803,7 +803,7 @@ class ChainBuilder(object):
                     rebase_state.add_constraints(sym_word == self._roparg_filler)
 
         # create the ropchain
-        res = RopChain(self.project, self, state=test_symbolic_state.copy(), rebase=self._rebase)
+        res = RopChain(self.project, self, state=test_symbolic_state.copy(), rebase=self._rebase, badbytes=self.badbytes)
         for g in gadgets:
             res.add_gadget(g)
 

--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -90,6 +90,7 @@ class ChainBuilder(object):
                                              registers, best_stack_change, rebase_regs)
         except angr.SimUnsatError:
             raise RopException("Couldn't set registers :(")
+        return chain
 
     # TODO handle mess ups by _find_reg_setting_gadgets and see if we can set a register in a syscall preamble
     # or if a register value is explicitly set to just the right value
@@ -176,18 +177,7 @@ class ChainBuilder(object):
 
         return chain
 
-    def write_to_mem(self, addr, string_data, fill_byte=b"\xff"):
-        """
-        :param addr: address to store the string
-        :param string_data: string to store
-        :param fill_byte: a byte to use to fill up the string if necessary
-        :return: a rop chain
-        """
-
-        if not (isinstance(fill_byte, bytes) and len(fill_byte) == 1):
-            print("fill_byte is not a one byte string, aborting")
-            return
-
+    def _gen_mem_write_gadgets(self, string_data):
         # create a dict of bytes per write to gadgets
         # assume we need intersection of addr_dependencies and data_dependencies to be 0
         # TODO could allow mem_reads as long as we control the address?
@@ -204,73 +194,98 @@ class ChainBuilder(object):
                         len(set(m_access.addr_controllers) & set(m_access.data_controllers)) == 0:
                     possible_gadgets.add(g)
 
-        # get the data from trying to set all the registers
-        registers = dict((reg, 0x41) for reg in self._reg_list)
-        l.debug("getting reg data for mem writes")
-        _, _, reg_data = self._find_reg_setting_gadgets(max_stack_change=0x50, **registers)
-        l.debug("trying mem_write gadgets")
-
-        # limit the maximum size of the chain
-        best_stack_change = 0x400
-        best_gadget = None
-        for t, vals in reg_data.items():
-            if vals[1] >= best_stack_change:
-                continue
-            for g in possible_gadgets:
-                mem_write = g.mem_writes[0]
-                if (set(mem_write.addr_dependencies) | set(mem_write.data_dependencies)).issubset(set(t)):
-                    stack_change = g.stack_change + vals[1]
-                    bytes_per_write = mem_write.data_size // 8
-                    num_writes = (len(string_data) + bytes_per_write - 1)//bytes_per_write
-                    stack_change *= num_writes
-                    if stack_change < best_stack_change:
-                        best_gadget = g
-                        best_stack_change = stack_change
-
-        # try again using partial_controllers
-        use_partial_controllers = False
-        best_stack_change = 0x400
-        if best_gadget is None:
-            use_partial_controllers = True
-            l.warning("Trying to use partial controllers for memory write")
+        while possible_gadgets:
+            # get the data from trying to set all the registers
+            registers = dict((reg, 0x41) for reg in self._reg_list)
             l.debug("getting reg data for mem writes")
-            _, _, reg_data = self._find_reg_setting_gadgets(max_stack_change=0x50, use_partial_controllers=True,
-                                                            **registers)
+            _, _, reg_data = self._find_reg_setting_gadgets(max_stack_change=0x50, **registers)
             l.debug("trying mem_write gadgets")
+
+            # limit the maximum size of the chain
+            best_stack_change = 0x400
+            best_gadget = None
             for t, vals in reg_data.items():
                 if vals[1] >= best_stack_change:
                     continue
                 for g in possible_gadgets:
                     mem_write = g.mem_writes[0]
-                    # we need the addr to not be partially controlled
-                    if (set(mem_write.addr_dependencies) | set(mem_write.data_dependencies)).issubset(set(t)) and \
-                            len(set(mem_write.addr_dependencies) & vals[3]) == 0:
+                    if (set(mem_write.addr_dependencies) | set(mem_write.data_dependencies)).issubset(set(t)):
                         stack_change = g.stack_change + vals[1]
-                        # only one byte at a time
-                        bytes_per_write = 1
+                        bytes_per_write = mem_write.data_size // 8
                         num_writes = (len(string_data) + bytes_per_write - 1)//bytes_per_write
                         stack_change *= num_writes
                         if stack_change < best_stack_change:
                             best_gadget = g
                             best_stack_change = stack_change
 
-        if best_gadget is None:
-            raise RopException("Couldnt set registers for any memory write gadget")
+            # try again using partial_controllers
+            use_partial_controllers = False
+            best_stack_change = 0x400
+            if best_gadget is None:
+                use_partial_controllers = True
+                l.warning("Trying to use partial controllers for memory write")
+                l.debug("getting reg data for mem writes")
+                _, _, reg_data = self._find_reg_setting_gadgets(max_stack_change=0x50, use_partial_controllers=True,
+                                                                **registers)
+                l.debug("trying mem_write gadgets")
+                for t, vals in reg_data.items():
+                    if vals[1] >= best_stack_change:
+                        continue
+                    for g in possible_gadgets:
+                        mem_write = g.mem_writes[0]
+                        # we need the addr to not be partially controlled
+                        if (set(mem_write.addr_dependencies) | set(mem_write.data_dependencies)).issubset(set(t)) and \
+                                len(set(mem_write.addr_dependencies) & vals[3]) == 0:
+                            stack_change = g.stack_change + vals[1]
+                            # only one byte at a time
+                            bytes_per_write = 1
+                            num_writes = (len(string_data) + bytes_per_write - 1)//bytes_per_write
+                            stack_change *= num_writes
+                            if stack_change < best_stack_change:
+                                best_gadget = g
+                                best_stack_change = stack_change
 
-        mem_write = best_gadget.mem_writes[0]
-        bytes_per_write = mem_write.data_size//8 if not use_partial_controllers else 1
-        l.debug("Now building the mem write chain")
+            yield best_gadget, use_partial_controllers
+            possible_gadgets.remove(best_gadget)
 
-        # build the chain
-        chain = RopChain(self.project, self, rebase=self._rebase, badbytes=self.badbytes)
-        for i in range(0, len(string_data), bytes_per_write):
-            to_write = string_data[i: i+bytes_per_write]
-            # pad if needed
-            if len(to_write) < bytes_per_write:
-                to_write += fill_byte * (bytes_per_write-len(to_write))
-            chain = chain + self._write_to_mem_with_gadget(best_gadget, addr + i, to_write, use_partial_controllers)
+    def write_to_mem(self, addr, string_data, fill_byte=b"\xff"):
+        """
+        :param addr: address to store the string
+        :param string_data: string to store
+        :param fill_byte: a byte to use to fill up the string if necessary
+        :return: a rop chain
+        """
 
-        return chain
+        if not (isinstance(fill_byte, bytes) and len(fill_byte) == 1):
+            print("fill_byte is not a one byte string, aborting")
+            return
+
+        gen = self._gen_mem_write_gadgets(string_data)
+        gadget, use_partial_controllers = next(gen, (None, None))
+
+        while gadget:
+            mem_write = gadget.mem_writes[0]
+            bytes_per_write = mem_write.data_size//8 if not use_partial_controllers else 1
+            l.debug("Now building the mem write chain")
+
+            try:
+                # build the chain
+                chain = RopChain(self.project, self, rebase=self._rebase, badbytes=self.badbytes)
+                for i in range(0, len(string_data), bytes_per_write):
+                    to_write = string_data[i: i+bytes_per_write]
+                    # pad if needed
+                    if len(to_write) < bytes_per_write:
+                        to_write += fill_byte * (bytes_per_write-len(to_write))
+                    chain = chain + self._write_to_mem_with_gadget(gadget, addr + i, to_write, use_partial_controllers)
+                return chain
+            except RopException:
+                pass
+
+            gadget, use_partial_controllers  = next(gen, (None, None))
+            if not gadget:
+                break
+
+        raise RopException("Fail to write data to memory :(")
 
     def add_to_mem(self, addr, value, data_size=None):
         """

--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -259,6 +259,9 @@ class ChainBuilder(object):
         if not (isinstance(fill_byte, bytes) and len(fill_byte) == 1):
             print("fill_byte is not a one byte string, aborting")
             return
+        if not isinstance(string_data, bytes):
+            print("string_data is not a byte string, aborting")
+            return
 
         gen = self._gen_mem_write_gadgets(string_data)
         gadget, use_partial_controllers = next(gen, (None, None))

--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -267,6 +267,7 @@ class ChainBuilder(object):
         gadget, use_partial_controllers = next(gen, (None, None))
 
         while gadget:
+            l.debug("[write_to_mem] trying mem_write gadget %s", gadget)
             mem_write = gadget.mem_writes[0]
             bytes_per_write = mem_write.data_size//8 if not use_partial_controllers else 1
             l.debug("Now building the mem write chain")

--- a/angrop/chain_builder/__init__.py
+++ b/angrop/chain_builder/__init__.py
@@ -17,7 +17,7 @@ from ..rop_gadget import RopGadget
 l = logging.getLogger("angrop.chain_builder")
 
 
-class ChainBuilder(object):
+class ChainBuilder:
     """
     This class provides functions to generate common ropchains based on existing gadgets.
     """
@@ -252,7 +252,7 @@ class ChainBuilder(object):
             chain = chain + self._write_to_mem_with_gadget(gadget, addr + i, to_write, use_partial_controllers)
         return chain
 
-    def write_to_mem(self, addr, string_data, fill_byte=b"\xff"):
+    def write_to_mem(self, addr, string_data, fill_byte=b"\xff"):# pylint:disable=inconsistent-return-statements
         """
         :param addr: address to store the string
         :param string_data: string to store
@@ -273,7 +273,7 @@ class ChainBuilder(object):
         while gadget:
             try:
                 return self._try_write_to_mem(gadget, use_partial_controllers, addr, string_data, fill_byte)
-            except RopException as e:
+            except RopException:
                 pass
             gadget, use_partial_controllers  = next(gen, (None, None))
 
@@ -528,7 +528,7 @@ class ChainBuilder(object):
                 if g.stack_change > g2.stack_change and ChainBuilder._has_same_effects(g, g2):
                     good = False
                     break
-                elif g.stack_change == g2.stack_change and g.addr > g2.addr and ChainBuilder._has_same_effects(g, g2):
+                if g.stack_change == g2.stack_change and g.addr > g2.addr and ChainBuilder._has_same_effects(g, g2):
                     good = False
                     break
             if good:
@@ -854,7 +854,7 @@ class ChainBuilder(object):
 
         # check keys
         search_regs = set()
-        for reg in registers.keys():
+        for reg in registers:
             search_regs.add(reg)
             if reg not in self._reg_list:
                 raise RopException("Register %s not in reg list" % reg)
@@ -863,7 +863,7 @@ class ChainBuilder(object):
 
         # find gadgets with sufficient partial control
         partial_controllers = dict()
-        for r in registers.keys():
+        for r in registers:
             partial_controllers[r] = set()
         if use_partial_controllers:
             partial_controllers = self._get_sufficient_partial_controllers(registers)

--- a/angrop/chain_builder/__init__.py
+++ b/angrop/chain_builder/__init__.py
@@ -1107,6 +1107,7 @@ class ChainBuilder:
 
     def _set_roparg_filler(self, roparg_filler):
         self._roparg_filler = roparg_filler
+        self._reg_setter._roparg_filler = roparg_filler
 
     # should also be able to do execve by providing writable memory
     # todo pivot stack

--- a/angrop/chain_builder/__init__.py
+++ b/angrop/chain_builder/__init__.py
@@ -235,9 +235,10 @@ class ChainBuilder(object):
             yield best_gadget, use_partial_controllers
             possible_gadgets.remove(best_gadget)
 
-    #@rop_utils.timeout(5)
+    @rop_utils.timeout(5)
     def _try_write_to_mem(self, gadget, use_partial_controllers, addr, string_data, fill_byte):
-        l.debug("building mem_write chain with gadget:\n%s", gadget)
+        gadget_code = str(self.project.factory.block(gadget.addr).capstone)
+        l.debug("building mem_write chain with gadget:\n%s", gadget_code)
         mem_write = gadget.mem_writes[0]
         bytes_per_write = mem_write.data_size//8 if not use_partial_controllers else 1
 

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from functools import cmp_to_key
 
 import angr
+from angr.errors import SimUnsatError
 
 
 from .. import rop_utils
@@ -36,7 +37,10 @@ class RegSetter:
             raise RopException("unknown registers: %s" % unknown_regs)
 
         gadgets = self._find_relevant_gadgets(**registers)
+        best_chain, _, _ = self._find_reg_setting_gadgets(modifiable_memory_range,
+                                                                       use_partial_controllers, **registers)
         chains = self._find_all_candidate_chains(gadgets, **registers)
+        chains = [best_chain] + chains
 
         if rebase_regs is None:
             rebase_regs = set()
@@ -48,7 +52,7 @@ class RegSetter:
             try:
                 return self._build_reg_setting_chain(chain, modifiable_memory_range,
                                                      registers, stack_change, rebase_regs)
-            except RopException:
+            except (RopException, SimUnsatError):
                 pass
 
         raise RopException("Couldn't set registers :(")
@@ -266,3 +270,240 @@ class RegSetter:
         if len(gadget_addrs) > 0:
             raise RopException("Didnt find all gadget addresses, something must've broke")
         return res
+
+    # todo allow user to specify rop chain location so that we can use read_mem gadgets to load values
+    # todo allow specify initial regs or dont clobber regs
+    # todo memcopy(from_addr, to_addr, len)
+    # todo handle "leave" then try to do a mem write on chess from codegate-finals
+    def _find_reg_setting_gadgets(self, modifiable_memory_range=None, use_partial_controllers=False,
+                                  max_stack_change=None, **registers):
+        """
+        Finds a list of gadgets which set the desired registers
+        This method currently only handles simple cases and will be improved later
+        :param registers:
+        :return:
+        """
+        if modifiable_memory_range is not None and len(modifiable_memory_range) != 2:
+            raise Exception("modifiable_memory_range should be a tuple (low, high)")
+
+        # check keys
+        search_regs = set()
+        for reg in registers.keys():
+            search_regs.add(reg)
+            if reg not in self._reg_set:
+                raise RopException("Register %s not in reg list" % reg)
+
+        # lets try doing a graph search to set registers, something like dijkstra's for minimum length
+
+        # find gadgets with sufficient partial control
+        partial_controllers = dict()
+        for r in registers.keys():
+            partial_controllers[r] = set()
+        if use_partial_controllers:
+            partial_controllers = self._get_sufficient_partial_controllers(registers)
+
+        # filter reg setting gadgets
+        gadgets = set(self._reg_setting_gadgets)
+        for s in partial_controllers.values():
+            gadgets.update(s)
+        gadgets = list(gadgets)
+        if modifiable_memory_range is None:
+            gadgets = [g for g in gadgets if
+                       len(g.mem_changes) == 0 and len(g.mem_writes) == 0 and len(g.mem_reads) == 0]
+        l.debug("finding best gadgets")
+
+        # each key is tuple of sorted registers
+        # use tuple (prev, total_stack_change, gadget, partial_controls)
+        data = dict()
+
+        to_process = list()
+        to_process.append((0, ()))
+        visited = set()
+        data[()] = (None, 0, None, set())
+        best_stack_change = 0xffffffff
+        best_reg_tuple = None
+        while to_process:
+            regs = heapq.heappop(to_process)[1]
+
+            if regs in visited:
+                continue
+            visited.add(regs)
+
+            if data[regs][1] >= best_stack_change:
+                continue
+            if max_stack_change is not None and data[regs][1] > max_stack_change:
+                continue
+
+            for g in gadgets:
+                # ignore gadgets which make a syscall when setting regs
+                if g.makes_syscall:
+                    continue
+                # ignore gadgets which don't have a positive stack change
+                if g.stack_change <= 0:
+                    continue
+
+                stack_change = data[regs][1]
+                new_stack_change = stack_change + g.stack_change
+                # if its longer than the best ignore
+                if new_stack_change >= best_stack_change:
+                    continue
+                # ignore base pointer moves for now
+                if g.bp_moves_to_sp:
+                    continue
+                # ignore if we only change controlled regs
+                start_regs = set(regs)
+                if g.changed_regs.issubset(start_regs - data[regs][3]):
+                    continue
+
+                end_regs, partial_regs = self._get_updated_controlled_regs(g, regs, data[regs], partial_controllers,
+                                                                           modifiable_memory_range)
+
+                # if we control any new registers try adding it
+                end_reg_tuple = tuple(sorted(end_regs))
+                npartial = len(partial_regs)
+                if len(end_regs - start_regs) > 0:
+                    # if we havent seen that tuple before, or payload is shorter or less partially controlled regs.
+                    end_data = data.get(end_reg_tuple, None)
+                    if end_reg_tuple not in data or \
+                            (new_stack_change < end_data[1] and npartial <= len(end_data[3])) or \
+                            (npartial < len(end_data[3])):
+                        # it improves the graph so add it
+                        data[end_reg_tuple] = (regs, new_stack_change, g, partial_regs)
+                        heapq.heappush(to_process, (new_stack_change, end_reg_tuple))
+
+                        if search_regs.issubset(end_regs):
+                            if new_stack_change < best_stack_change:
+                                best_stack_change = new_stack_change
+                                best_reg_tuple = end_reg_tuple
+
+        # if the best_reg_tuple is None then we failed to set the desired registers :(
+        if best_reg_tuple is None:
+            return None, None, data
+
+        # get the actual addresses
+        gadgets_reverse = []
+        curr_tuple = best_reg_tuple
+        while curr_tuple != ():
+            gadgets_reverse.append(data[curr_tuple][2])
+            curr_tuple = data[curr_tuple][0]
+
+        gadgets = gadgets_reverse[::-1]
+
+        return gadgets, best_stack_change, data
+
+    def _get_sufficient_partial_controllers(self, registers):
+        sufficient_partial_controllers = defaultdict(set)
+        for g in self._reg_setting_gadgets:
+            for reg in g.changed_regs:
+                if reg in registers:
+                    if self._check_if_sufficient_partial_control(g, reg, registers[reg]):
+                        sufficient_partial_controllers[reg].add(g)
+        return sufficient_partial_controllers
+
+    @staticmethod
+    def _get_updated_controlled_regs(gadget, regs, data_tuple, partial_controllers, modifiable_memory_range=None):
+        g = gadget
+        start_regs = set(regs)
+        partial_regs = data_tuple[3]
+        usable_regs = start_regs - partial_regs
+        end_regs = set(start_regs)
+
+        # skip ones that change memory if no modifiable_memory_addr
+        if modifiable_memory_range is None and \
+                (len(g.mem_reads) > 0 or len(g.mem_writes) > 0 or len(g.mem_changes) > 0):
+            return set(), set()
+        elif modifiable_memory_range is not None:
+            # check if we control all the memory reads/writes/changes
+            all_mem_accesses = g.mem_changes + g.mem_reads + g.mem_writes
+            mem_accesses_controlled = True
+            for m_access in all_mem_accesses:
+                for reg in m_access.addr_dependencies:
+                    if reg not in usable_regs:
+                        mem_accesses_controlled = False
+                    usable_regs -= m_access.addr_dependencies
+            if not mem_accesses_controlled:
+                return set(), set()
+
+        # analyze  all registers that we control
+        for reg in g.changed_regs:
+            end_regs.discard(reg)
+            partial_regs.discard(reg)
+
+        # for any reg that can be fully controlled check if we control its dependencies
+        for reg in g.reg_controllers.keys():
+            has_deps = True
+            for dep in g.reg_dependencies[reg]:
+                if dep not in usable_regs:
+                    has_deps = False
+            if has_deps:
+                for dep in g.reg_dependencies[reg]:
+                    end_regs.discard(dep)
+                    usable_regs.discard(dep)
+                end_regs.add(reg)
+            else:
+                end_regs.discard(reg)
+
+        # for all the changed regs that we dont fully control, we see if the partial control is good enough
+        for reg in set(g.changed_regs) - set(g.reg_controllers.keys()):
+            if reg in partial_controllers and g in partial_controllers[reg]:
+                # partial control is good enough so now check if we control all the dependencies
+                if reg not in g.reg_dependencies or set(g.reg_dependencies[reg]).issubset(usable_regs):
+                    # we control all the dependencies add it and remove them from the usable regs
+                    partial_regs.add(reg)
+                    end_regs.add(reg)
+                    if reg in g.reg_dependencies:
+                        usable_regs -= set(g.reg_dependencies[reg])
+                        end_regs -= set(g.reg_dependencies[reg])
+
+        for reg in g.popped_regs:
+            end_regs.add(reg)
+
+        return end_regs, partial_regs
+
+    def _get_single_ret(self):
+        # start with a ret instruction
+        ret_addr = None
+        for g in self._reg_setting_gadgets:
+            if len(g.changed_regs) == 0 and len(g.mem_writes) == 0 and \
+                    len(g.mem_reads) == 0 and len(g.mem_changes) == 0 and \
+                    g.stack_change == self.project.arch.bytes:
+                ret_addr = g.addr
+                break
+        return ret_addr
+
+    def _check_if_sufficient_partial_control(self, gadget, reg, value):
+        # doesnt change it
+        if reg not in gadget.changed_regs:
+            return False
+        # does syscall
+        if gadget.makes_syscall:
+            return False
+        # can be controlled completely, not a partial control
+        if reg in gadget.reg_controllers or reg in gadget.popped_regs:
+            return False
+        # make sure the register doesnt depend on itself
+        if reg in gadget.reg_dependencies and reg in gadget.reg_dependencies[reg]:
+            return False
+        # make sure the gadget doesnt pop bp
+        if gadget.bp_moves_to_sp:
+            return False
+
+        # set the register
+        state = rop_utils.make_symbolic_state(self.project, self._reg_set)
+        state.registers.store(reg, 0)
+        state.regs.ip = gadget.addr
+        # store A's past the end of the stack
+        state.memory.store(state.regs.sp + gadget.stack_change, state.solver.BVV(b"A"*0x100))
+
+        succ = rop_utils.step_to_unconstrained_successor(project=self.project, state=state)
+        # successor
+        if succ.ip is succ.registers.load(reg):
+            return False
+
+        if succ.solver.solution(succ.registers.load(reg), value):
+            # make sure wasnt a symbolic read
+            for var in succ.registers.load(reg).variables:
+                if "symbolic_read" in var:
+                    return False
+            return True
+        return False

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -40,7 +40,8 @@ class RegSetter:
         best_chain, _, _ = self._find_reg_setting_gadgets(modifiable_memory_range,
                                                                        use_partial_controllers, **registers)
         chains = self._find_all_candidate_chains(gadgets, **registers)
-        chains = [best_chain] + chains
+        if best_chain:
+            chains = [best_chain] + chains
 
         if rebase_regs is None:
             rebase_regs = set()

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -1,0 +1,268 @@
+import heapq
+import logging
+from collections import defaultdict
+from functools import cmp_to_key
+
+import angr
+
+
+from .. import rop_utils
+from ..rop_chain import RopChain
+from ..errors import RopException
+
+l = logging.getLogger("angrop.chain_builder.reg_setter")
+
+class RegSetter:
+    """
+    TODO: get rid of Salls's code
+    """
+    def __init__(self, project, gadgets, reg_list=None, badbytes=None, rebase=False, filler=None):
+        self.project = project
+        self._reg_set = set(reg_list)
+        self._badbytes = badbytes
+        self._rebase = rebase
+
+        self._reg_setting_gadgets = self._filter_gadgets(gadgets)
+        self._roparg_filler = filler
+
+    def run(self, modifiable_memory_range=None, use_partial_controllers=False, rebase_regs=None, **registers):
+        # TODO: nuke or support rebase_regs
+        if len(registers) == 0:
+            return RopChain(self.project, None, rebase=self._rebase, badbytes=self._badbytes)
+
+        # sanity check
+        unknown_regs = set(registers.keys()) - self._reg_set
+        if unknown_regs:
+            raise RopException("unknown registers: %s" % unknown_regs)
+
+        gadgets = self._find_relevant_gadgets(**registers)
+        chains = self._find_all_candidate_chains(gadgets, **registers)
+
+        if rebase_regs is None:
+            rebase_regs = set()
+
+        for chain in chains:
+            chain_str = '\n-----\n'.join([str(self.project.factory.block(g.addr).capstone)for g in chain])
+            l.debug("building reg_setting chain with chain:\n%s", chain_str)
+            stack_change = sum(x.stack_change for x in chain)
+            try:
+                return self._build_reg_setting_chain(chain, modifiable_memory_range,
+                                                     registers, stack_change, rebase_regs)
+            except RopException:
+                pass
+
+        raise RopException("Couldn't set registers :(")
+
+    def _find_relevant_gadgets(self, **registers):
+        """
+        find gadgets that may pop/load/change requested registers
+        """
+        gadgets = set({})
+        for g in self._reg_setting_gadgets:
+            if g.makes_syscall:
+                continue
+            for reg in registers:
+                if reg in g.popped_regs:
+                    gadgets.add(g)
+                if reg in g.changed_regs:
+                    gadgets.add(g)
+                if reg in g.reg_dependencies.keys():
+                    gadgets.add(g)
+        return gadgets
+
+    def _recursively_find_chains(self, gadgets, chain, preserve_regs, todo_regs):
+        if not todo_regs:
+            return [chain]
+
+        todo_list = []
+        for g in gadgets:
+            set_regs = g.popped_regs.intersection(todo_regs)
+            if not set_regs:
+                continue
+            destory_regs = g.changed_regs.intersection(preserve_regs)
+            if destory_regs - set_regs:
+                continue
+            new_preserve = preserve_regs.copy()
+            new_preserve.update(set_regs)
+            new_chain = chain.copy()
+            new_chain.append(g)
+            todo_list.append((new_chain, new_preserve, todo_regs-set_regs))
+
+        res = []
+        for todo in todo_list:
+            res += self._recursively_find_chains(gadgets, *todo)
+        return res
+
+    @staticmethod
+    def _sort_chains(chains):
+        def cmp_func(chain1, chain2):
+            stack_change1 = sum(x.stack_change for x in chain1)
+            stack_change2 = sum(x.stack_change for x in chain2)
+            if stack_change1 > stack_change2:
+                return 1
+            elif stack_change1 < stack_change2:
+                return -1
+
+            num_mem_access1 = sum(x.num_mem_access for x in chain1)
+            num_mem_access2 = sum(x.num_mem_access for x in chain2)
+            if num_mem_access1 > num_mem_access2:
+                return 1
+            if num_mem_access1 < num_mem_access2:
+                return -1
+            return 0
+        return sorted(chains, key=cmp_to_key(cmp_func))
+
+
+    def _find_all_candidate_chains(self, gadgets, **registers):
+        """
+        find all pop only chains by BFS search
+        TODO: handle moves
+        """
+        regs = set(registers.keys())
+        chains = self._recursively_find_chains(gadgets, [], set({}), regs)
+        return self._sort_chains(chains)
+
+    def _same_reg_effects(self, g1, g2):
+        if g1.popped_regs != g2.popped_regs:
+            return False
+        if g1.bp_moves_to_sp != g2.bp_moves_to_sp:
+            return False
+        if g1.reg_dependencies != g2.reg_dependencies:
+            return False
+        return True
+
+    def _strictly_better(self, g1, g2):
+        if not self._same_reg_effects(g1, g2):
+            return False
+        if len(g1.changed_regs) <= len(g2.changed_regs) and g1.block_length <= g2.block_length:
+            return True
+        return False
+
+    def _filter_gadgets(self, gadgets):
+        """
+        filter gadgets having the same effect
+        """
+        gadgets = set(gadgets)
+        skip = set({})
+        while True:
+            to_remove = set({})
+            for g in gadgets-skip:
+                to_remove.update({x for x in gadgets-{g} if self._strictly_better(g, x)})
+                if to_remove:
+                    break
+                skip.add(g)
+            if not to_remove:
+                break
+            gadgets -= to_remove
+        return gadgets
+
+
+    ################# Salls's Code Space ###################
+    @rop_utils.timeout(2)
+    def _build_reg_setting_chain(self, gadgets, modifiable_memory_range, register_dict, stack_change, rebase_regs):
+        """
+        This function figures out the actual values needed in the chain
+        for a particular set of gadgets and register values
+        This is done by stepping a symbolic state through each gadget
+        then constraining the final registers to the values that were requested
+        FIXME: trim this disgusting function
+        """
+
+        # create a symbolic state
+        test_symbolic_state = rop_utils.make_symbolic_state(self.project, self._reg_set)
+        addrs = [g.addr for g in gadgets]
+        addrs.append(test_symbolic_state.solver.BVS("next_addr", self.project.arch.bits))
+
+        arch_bytes = self.project.arch.bytes
+        arch_endness = self.project.arch.memory_endness
+
+        # emulate a 'pop pc' of the first gadget
+        state = test_symbolic_state
+        state.regs.ip = addrs[0]
+        # the stack pointer must begin pointing to our first gadget
+        state.add_constraints(state.memory.load(state.regs.sp, arch_bytes, endness=arch_endness) == addrs[0])
+        # push the stack pointer down, like a pop would do
+        state.regs.sp += arch_bytes
+        state.solver._solver.timeout = 5000
+
+        # step through each gadget
+        # for each gadget, constrain memory addresses and add constraints for the successor
+        for addr in addrs[1:]:
+            succ = rop_utils.step_to_unconstrained_successor(self.project, state)
+            state.add_constraints(succ.regs.ip == addr)
+            # constrain reads/writes
+            for a in succ.log.actions:
+                if a.type == "mem" and a.addr.ast.symbolic:
+                    if modifiable_memory_range is None:
+                        raise RopException("Symbolic memory address when there shouldnt have been")
+                    test_symbolic_state.add_constraints(a.addr.ast >= modifiable_memory_range[0])
+                    test_symbolic_state.add_constraints(a.addr.ast < modifiable_memory_range[1])
+            test_symbolic_state.add_constraints(succ.regs.ip == addr)
+            # get to the unconstrained successor
+            state = rop_utils.step_to_unconstrained_successor(self.project, state)
+
+        # re-adjuest the stack pointer
+        sp = test_symbolic_state.regs.sp
+        sp -= arch_bytes
+        bytes_per_pop = arch_bytes
+
+        # constrain the final registers
+        rebase_state = test_symbolic_state.copy()
+        for r, v in register_dict.items():
+            test_symbolic_state.add_constraints(state.registers.load(r) == v)
+
+        # to handle register values that should depend on the binary base address
+        if len(rebase_regs) > 0:
+            for r, v in register_dict.items():
+                if r in rebase_regs:
+                    rebase_state.add_constraints(state.registers.load(r) == (v + 0x41414141))
+                else:
+                    rebase_state.add_constraints(state.registers.load(r) == v)
+
+        # constrain the "filler" values
+        if self._roparg_filler is not None:
+            for i in range(stack_change // bytes_per_pop):
+                sym_word = test_symbolic_state.memory.load(sp + bytes_per_pop*i, bytes_per_pop,
+                                                           endness=self.project.arch.memory_endness)
+                # check if we can constrain val to be the roparg_filler
+                if test_symbolic_state.solver.satisfiable((sym_word == self._roparg_filler,)) and \
+                        rebase_state.solver.satisfiable((sym_word == self._roparg_filler,)):
+                    # constrain the val to be the roparg_filler
+                    test_symbolic_state.add_constraints(sym_word == self._roparg_filler)
+                    rebase_state.add_constraints(sym_word == self._roparg_filler)
+
+        # create the ropchain
+        res = RopChain(self.project, self, state=test_symbolic_state.copy(), rebase=self._rebase, badbytes=self._badbytes)
+        for g in gadgets:
+            res.add_gadget(g)
+
+        # iterate through the stack values that need to be in the chain
+        gadget_addrs = [g.addr for g in gadgets]
+        for i in range(stack_change // bytes_per_pop):
+            sym_word = test_symbolic_state.memory.load(sp + bytes_per_pop*i, bytes_per_pop,
+                                                       endness=self.project.arch.memory_endness)
+
+            val = test_symbolic_state.solver.eval(sym_word)
+
+            if len(rebase_regs) > 0:
+                val2 = rebase_state.solver.eval(rebase_state.memory.load(sp + bytes_per_pop*i, bytes_per_pop,
+                                                                        endness=self.project.arch.memory_endness))
+                if (val2 - val) & (2**self.project.arch.bits - 1) == 0x41414141:
+                    res.add_value(val, needs_rebase=True)
+                elif val == val2 and len(gadget_addrs) > 0 and val == gadget_addrs[0]:
+                    res.add_value(val, needs_rebase=True)
+                    gadget_addrs = gadget_addrs[1:]
+                elif val == val2:
+                    res.add_value(sym_word, needs_rebase=False)
+                else:
+                    raise RopException("Rebase Failed")
+            else:
+                if len(gadget_addrs) > 0 and val == gadget_addrs[0]:
+                    res.add_value(val, needs_rebase=True)
+                    gadget_addrs = gadget_addrs[1:]
+                else:
+                    res.add_value(sym_word, needs_rebase=False)
+
+        if len(gadget_addrs) > 0:
+            raise RopException("Didnt find all gadget addresses, something must've broke")
+        return res

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -50,8 +50,10 @@ class RegSetter:
             l.debug("building reg_setting chain with chain:\n%s", chain_str)
             stack_change = sum(x.stack_change for x in chain)
             try:
-                return self._build_reg_setting_chain(chain, modifiable_memory_range,
+                chain = self._build_reg_setting_chain(chain, modifiable_memory_range,
                                                      registers, stack_change, rebase_regs)
+                chain._concretize_chain_values()
+                return chain
             except (RopException, SimUnsatError):
                 pass
 

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -3,7 +3,6 @@ import logging
 from collections import defaultdict
 from functools import cmp_to_key
 
-import angr
 from angr.errors import SimUnsatError
 
 
@@ -129,7 +128,8 @@ class RegSetter:
         chains = self._recursively_find_chains(gadgets, [], set({}), regs)
         return self._sort_chains(chains)
 
-    def _same_reg_effects(self, g1, g2):
+    @staticmethod
+    def _same_reg_effects(g1, g2):
         if g1.popped_regs != g2.popped_regs:
             return False
         if g1.bp_moves_to_sp != g2.bp_moves_to_sp:
@@ -291,7 +291,7 @@ class RegSetter:
 
         # check keys
         search_regs = set()
-        for reg in registers.keys():
+        for reg in registers:
             search_regs.add(reg)
             if reg not in self._reg_set:
                 raise RopException("Register %s not in reg list" % reg)
@@ -300,7 +300,7 @@ class RegSetter:
 
         # find gadgets with sufficient partial control
         partial_controllers = dict()
-        for r in registers.keys():
+        for r in registers:
             partial_controllers[r] = set()
         if use_partial_controllers:
             partial_controllers = self._get_sufficient_partial_controllers(registers)

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -118,7 +118,6 @@ class RegSetter:
             return 0
         return sorted(chains, key=cmp_to_key(cmp_func))
 
-
     def _find_all_candidate_chains(self, gadgets, **registers):
         """
         find all pop only chains by BFS search

--- a/angrop/gadget_analyzer.py
+++ b/angrop/gadget_analyzer.py
@@ -143,7 +143,7 @@ class GadgetAnalyzer(object):
         except RopException as e:
             l.debug("... %s", e)
             return None
-        except claripy.ClaripyFrontendError as e:
+        except (claripy.ClaripyFrontendError, angr.engines.vex.claripy.ccall.CCallMultivaluedException) as e:
             l.warning("... claripy error: %s", e)
             return None
 

--- a/angrop/gadget_analyzer.py
+++ b/angrop/gadget_analyzer.py
@@ -12,6 +12,7 @@ from .errors import RopException, RegNotFoundException
 l = logging.getLogger("angrop.gadget_analyzer")
 
 
+
 class GadgetAnalyzer(object):
     def __init__(self, project, reg_list, max_block_size, fast_mode, max_sym_mem_accesses):
         # params
@@ -34,6 +35,7 @@ class GadgetAnalyzer(object):
         # solve cache
         self._solve_cache = dict()
 
+    @rop_utils.timeout(3)
     def analyze_gadget(self, addr):
         """
         :param addr: address to analyze for a gadget

--- a/angrop/gadget_analyzer.py
+++ b/angrop/gadget_analyzer.py
@@ -80,11 +80,15 @@ class GadgetAnalyzer(object):
             # for jump gadget, record the jump target register
             if gadget_type == "jump":
                 state = self._test_symbolic_state.copy()
+                insns = self.project.factory.block(addr).capstone.insns
                 if state.project.arch.name.startswith("MIPS"):
-                    last_inst_addr = self.project.factory.block(addr).capstone.insns[-2].address
+                    idx = -2 # delayed slot
                 else:
-                    last_inst_addr = self.project.factory.block(addr).capstone.insns[-1].address
-                state.ip = last_inst_addr
+                    idx = -1
+                if len(insns) < abs(idx):
+                    return None
+                jump_inst_addr = insns[idx].address
+                state.ip = jump_inst_addr
                 succ = rop_utils.step_to_unconstrained_successor(self.project, state=state)
                 reg = list(succ.ip.variables)[0].split('_', 1)[1].rsplit('-')[0]
                 this_gadget.jump_reg = reg

--- a/angrop/gadget_analyzer.py
+++ b/angrop/gadget_analyzer.py
@@ -14,14 +14,13 @@ l = logging.getLogger("angrop.gadget_analyzer")
 
 
 class GadgetAnalyzer(object):
-    def __init__(self, project, reg_list, max_block_size, fast_mode, max_sym_mem_accesses, badbytes):
+    def __init__(self, project, reg_list, max_block_size, fast_mode, max_sym_mem_accesses):
         # params
         self.project = project
         self._reg_list = reg_list
         self._max_block_size = max_block_size
         self._fast_mode = fast_mode
         self._max_sym_mem_accesses = max_sym_mem_accesses
-        self._badbytes = badbytes
 
         # initial state that others are based off
         self._stack_length = 80
@@ -46,8 +45,6 @@ class GadgetAnalyzer(object):
 
         # first check if the block makes sense
         if not self._block_makes_sense(addr):
-            return None
-        if self._contain_badbytes(addr):
             return None
 
         try:
@@ -714,18 +711,6 @@ class GadgetAnalyzer(object):
                 except RegNotFoundException as e:
                     l.debug(e)
         return all_reg_writes
-
-    # inspired by ropper
-    def _contain_badbytes(self, addr):
-        n_bytes = self.project.arch.bytes
-
-        for b in self._badbytes:
-            tmp_addr = addr
-            for _ in range(n_bytes):
-                if (tmp_addr & 0xff) == b:
-                    return True
-                tmp_addr >>= 8
-        return False
 
 
 # TODO ip setters, ie call rax

--- a/angrop/gadget_analyzer.py
+++ b/angrop/gadget_analyzer.py
@@ -174,9 +174,11 @@ class GadgetAnalyzer(object):
                     return False
             # disable conditional jumps, for now
             # FIXME: we should handle conditional jumps, they are useful
+            conditional_postfix = ['eq', 'ne', 'cs', 'hs', 'cc', 'lo', 'mi', 'pl',
+                                  'vs', 'vc', 'hi', 'ls', 'ge', 'lt', 'gt', 'le', 'al']
             if self.project.arch.name.startswith("ARM"):
-                for stmt in block.vex.statements:
-                    if type(stmt) == pyvex.stmt.Exit:
+                for insn in block.capstone.insns:
+                    if insn.insn.mnemonic[-2:] in conditional_postfix:
                         return False
 
             if block.vex.jumpkind == 'Ijk_NoDecode':

--- a/angrop/gadget_analyzer.py
+++ b/angrop/gadget_analyzer.py
@@ -172,6 +172,12 @@ class GadgetAnalyzer(object):
                     return False
                 if block.size < 1 or block.bytes[0] == 0x4f:
                     return False
+            # disable conditional jumps, for now
+            # FIXME: we should handle conditional jumps, they are useful
+            if self.project.arch.name.startswith("ARM"):
+                for stmt in block.vex.statements:
+                    if type(stmt) == pyvex.stmt.Exit:
+                        return False
 
             if block.vex.jumpkind == 'Ijk_NoDecode':
                 l.debug("... not decodable")

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -61,6 +61,7 @@ class ROP(Analysis):
         """
 
         # params
+        self._is_thumb = is_thumb
         self._max_block_size, self._max_sym_mem_accesses = self._get_default_config()
         if max_block_size:
             self._max_block_size = max_block_size
@@ -68,7 +69,6 @@ class ROP(Analysis):
             self._max_sym_mem_accesses = max_sym_mem_accesses
         self._only_check_near_rets = only_check_near_rets
         self._rebase = rebase
-        self._is_thumb = is_thumb
 
         a = self.project.arch
         self._sp_reg = a.register_names[a.sp_offset]

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -45,7 +45,7 @@ class ROP(Analysis):
     Additionally, all public methods from ChainBuilder are copied into ROP.
     """
 
-    def __init__(self, only_check_near_rets=True, max_block_size=None, max_sym_mem_accesses=None, fast_mode=None):
+    def __init__(self, only_check_near_rets=True, max_block_size=None, max_sym_mem_accesses=None, fast_mode=None, rebase=True):
         """
         Initializes the rop gadget finder
         :param only_check_near_rets: If true we skip blocks that are not near rets
@@ -53,6 +53,8 @@ class ROP(Analysis):
                                gadgets so we limit the size we consider
         :param fast_mode: if set to True sets options to run fast, if set to False sets options to find more gadgets
                           if set to None makes a decision based on the size of the binary
+        :param rebase:    if set to True, angrop will try to rebase the gadgets with its best effort
+                          if set to False, angrop will use the memory mapping in angr in the ropchain
         :return:
         """
 
@@ -63,6 +65,7 @@ class ROP(Analysis):
         if max_sym_mem_accesses:
             self._max_sym_mem_accesses = max_sym_mem_accesses
         self._only_check_near_rets = only_check_near_rets
+        self._rebase = rebase
 
         a = self.project.arch
         self._sp_reg = a.register_names[a.sp_offset]
@@ -273,7 +276,7 @@ class ROP(Analysis):
         elif len(self.gadgets) > 0:
             self._chain_builder = chain_builder.ChainBuilder(self.project, self.gadgets, self._duplicates,
                                                              self._reg_list, self._base_pointer, self.badbytes,
-                                                             self.roparg_filler)
+                                                             self.roparg_filler, rebase=self._rebase)
             return self._chain_builder
         else:
             raise Exception("No gadgets available, call find_gadgets() or load_gadgets() if you haven't already.")

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -154,7 +154,7 @@ class ROP(Analysis):
                num_to_check, self._max_block_size)
 
         self._gadget_analyzer = gadget_analyzer.GadgetAnalyzer(self.project, self._reg_list, self._max_block_size,
-                                                               self._fast_mode, self._max_sym_mem_accesses)
+                                                               self._fast_mode, self._max_sym_mem_accesses, self.badbytes)
 
     def find_gadgets(self, processes=4, show_progress=True):
         """
@@ -246,6 +246,7 @@ class ROP(Analysis):
         if not isinstance(badbytes, list):
             print("Require a list, e.g: [0x00, 0x09]")
             return
+        badbytes = [x if type(x) == int else ord(x) for x in badbytes]
         self.badbytes = badbytes
         if len(self.gadgets) > 0:
             self.chain_builder._set_badbytes(self.badbytes)

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -304,13 +304,12 @@ class ROP(Analysis):
     def chain_builder(self):
         if self._chain_builder is not None:
             return self._chain_builder
-        elif len(self._gadgets) > 0:
-            self._chain_builder = chain_builder.ChainBuilder(self.project, self.gadgets, self._duplicates,
-                                                             self._reg_list, self._base_pointer, self.badbytes,
-                                                             self.roparg_filler, rebase=self._rebase)
-            return self._chain_builder
-        else:
-            raise Exception("No gadgets available, call find_gadgets() or load_gadgets() if you haven't already.")
+        if len(self._gadgets) == 0:
+            l.warning("Could not find gadgets for %s, check your badbytes and make sure find_gadgets() or load_gadgets() was called.", self.project)
+        self._chain_builder = chain_builder.ChainBuilder(self.project, self.gadgets, self._duplicates,
+                                                         self._reg_list, self._base_pointer, self.badbytes,
+                                                         self.roparg_filler, rebase=self._rebase)
+        return self._chain_builder
 
     def _block_has_ip_relative(self, addr, bl):
         """

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -6,7 +6,10 @@ class RopChain(object):
     """
     This class holds rop chains returned by the rop chain building methods such as rop.set_regs()
     """
-    def __init__(self, project, rop, state=None):
+    def __init__(self, project, rop, state=None, rebase=True):
+        """
+        rebase=False will force everything to use the addresses in angr
+        """
         self._p = project
         self._rop = rop
 
@@ -18,6 +21,7 @@ class RopChain(object):
         self._blank_state = self._p.factory.blank_state() if state is None else state
         self._pie = self._p.loader.main_object.image_base_delta != 0
         self._rebase_val = self._blank_state.solver.BVS("base", self._p.arch.bits)
+        self._rebase = rebase
 
     def __add__(self, other):
         # need to add the values from the other's stack and the constraints to the result state
@@ -34,7 +38,7 @@ class RopChain(object):
 
     def add_value(self, value, needs_rebase=False):
         # override rebase if its not pie
-        if not self._pie:
+        if not self._rebase or not self._pie:
             needs_rebase = False
         if needs_rebase:
             value -= self._p.loader.main_object.mapped_base
@@ -152,6 +156,7 @@ class RopChain(object):
         cp._blank_state = self._blank_state.copy()
         cp._pie = self._pie
         cp._rebase_val = self._rebase_val
+        cp._rebase = self._rebase
 
         return cp
 

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -3,7 +3,7 @@ from .errors import RopException
 
 from cle.address_translator import AT
 
-class RopChain(object):
+class RopChain:
     """
     This class holds rop chains returned by the rop chain building methods such as rop.set_regs()
     """

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -119,7 +119,7 @@ class RopChain(object):
         sp = test_state.regs.sp
         return test_state.memory.load(sp, self.payload_len)
 
-    def print_payload_code(self, constraints=None, print_instructions=True):
+    def payload_code(self, constraints=None, print_instructions=True):
         """
         :param print_instructions: prints the instructions that the rop gadgets use
         :return: prints the code for the rop payload
@@ -158,7 +158,10 @@ class RopChain(object):
             else:
                 payload += "chain += " + pack % value + instruction_code
             payload += "\n"
-        print(payload)
+        return payload
+
+    def print_payload_code(self, constraints=None, print_instructions=True):
+        print(self.payload_code(constraints=constraints, print_instructions=print_instructions))
 
     def copy(self):
         cp = RopChain(self._p, self._rop)
@@ -174,4 +177,4 @@ class RopChain(object):
         return cp
 
     def __str__(self):
-        return self.payload_str()
+        return self.payload_code()

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -1,4 +1,5 @@
 from . import rop_utils
+from .errors import RopException
 
 from cle.address_translator import AT
 
@@ -107,6 +108,8 @@ class RopChain(object):
                 test_state.stack_push(value)
         sp = test_state.regs.sp
         rop_str = test_state.solver.eval(test_state.memory.load(sp, self.payload_len), cast_to=bytes)
+        if any(bytes([c]) in rop_str for c in self.badbytes):
+            raise RopException()
         return rop_str
 
     def payload_bv(self):

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -56,6 +56,7 @@ class RopChain(object):
         """
         self._blank_state.add_constraints(cons)
 
+    @rop_utils.timeout(3)
     def _concretize_chain_values(self, constraints=None):
         """
         we all the flexibilty of chains to have symbolic values, this helper function

--- a/angrop/rop_gadget.py
+++ b/angrop/rop_gadget.py
@@ -76,6 +76,8 @@ class RopGadget(object):
         self.block_length = None
         self.makes_syscall = False
         self.starts_with_syscall = False
+        self.gadget_type = None
+        self.jump_reg = None
 
     def __str__(self):
         s = "Gadget %#x\n" % self.addr
@@ -154,6 +156,8 @@ class RopGadget(object):
         out.block_length = self.block_length
         out.makes_syscall = self.makes_syscall
         out.starts_with_syscall = self.starts_with_syscall
+        out.gadget_type = self.gadget_type
+        out.jump_reg = self.jump_reg
         return out
 
 

--- a/angrop/rop_gadget.py
+++ b/angrop/rop_gadget.py
@@ -80,6 +80,10 @@ class RopGadget(object):
         self.jump_reg = None
         self.pc_reg = None
 
+    @property
+    def num_mem_access(self):
+        return len(self.mem_reads) + len(self.mem_writes) + len(self.mem_changes)
+
     def __str__(self):
         s = "Gadget %#x\n" % self.addr
         if self.bp_moves_to_sp:

--- a/angrop/rop_gadget.py
+++ b/angrop/rop_gadget.py
@@ -78,6 +78,7 @@ class RopGadget(object):
         self.starts_with_syscall = False
         self.gadget_type = None
         self.jump_reg = None
+        self.pc_reg = None
 
     def __str__(self):
         s = "Gadget %#x\n" % self.addr
@@ -158,6 +159,7 @@ class RopGadget(object):
         out.starts_with_syscall = self.starts_with_syscall
         out.gadget_type = self.gadget_type
         out.jump_reg = self.jump_reg
+        out.pc_reg = self.pc_reg
         return out
 
 

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -232,7 +232,7 @@ class TimeoutError(Exception):
 def timeout(seconds_before_timeout):
     def decorate(f):
         def handler(signum, frame):
-            raise RopException("timeout")
+            raise RopException("[angrop] Timeout!")
         def new_f(*args, **kwargs):
             old = signal.signal(signal.SIGALRM, handler)
             old_time_left = signal.alarm(seconds_before_timeout)

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -1,3 +1,6 @@
+import time
+import signal
+
 import angr
 import claripy
 
@@ -219,3 +222,30 @@ def step_to_unconstrained_successor(project, state, max_steps=2, allow_simproced
 
     except (angr.errors.AngrError, angr.errors.SimError):
         raise RopException("Does not get to a single unconstrained successor")
+
+class TimeoutError(Exception):
+    def __init__(self, value = "Timed Out"):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
+def timeout(seconds_before_timeout):
+    def decorate(f):
+        def handler(signum, frame):
+            raise RopException("timeout")
+        def new_f(*args, **kwargs):
+            old = signal.signal(signal.SIGALRM, handler)
+            old_time_left = signal.alarm(seconds_before_timeout)
+            if 0 < old_time_left < second_before_timeout: # never lengthen existing timer
+                signal.alarm(old_time_left)
+            start_time = time.time()
+            try:
+                result = f(*args, **kwargs)
+            finally:
+                if old_time_left > 0: # deduct f's run time from the saved timer
+                    old_time_left -= time.time() - start_time
+                signal.signal(signal.SIGALRM, old)
+                signal.alarm(old_time_left)
+            return result
+        return new_f
+    return decorate

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -232,18 +232,19 @@ class TimeoutError(Exception):
 def timeout(seconds_before_timeout):
     def decorate(f):
         def handler(signum, frame):
+            print("[angrop] Timeout")
             raise RopException("[angrop] Timeout!")
         def new_f(*args, **kwargs):
             old = signal.signal(signal.SIGALRM, handler)
             old_time_left = signal.alarm(seconds_before_timeout)
-            if 0 < old_time_left < second_before_timeout: # never lengthen existing timer
+            if 0 < old_time_left < seconds_before_timeout: # never lengthen existing timer
                 signal.alarm(old_time_left)
             start_time = time.time()
             try:
                 result = f(*args, **kwargs)
             finally:
                 if old_time_left > 0: # deduct f's run time from the saved timer
-                    old_time_left -= time.time() - start_time
+                    old_time_left -= int(time.time() - start_time)
                 signal.signal(signal.SIGALRM, old)
                 signal.alarm(old_time_left)
             return result

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -220,18 +220,12 @@ def step_to_unconstrained_successor(project, state, max_steps=2, allow_simproced
             raise RopException("Does not get to an unconstrained successor")
         return succ.unconstrained_successors[0]
 
-    except (angr.errors.AngrError, angr.errors.SimError):
-        raise RopException("Does not get to a single unconstrained successor")
-
-class TimeoutError(Exception):
-    def __init__(self, value = "Timed Out"):
-        self.value = value
-    def __str__(self):
-        return repr(self.value)
+    except (angr.errors.AngrError, angr.errors.SimError) as e:
+        raise RopException("Does not get to a single unconstrained successor") from e
 
 def timeout(seconds_before_timeout):
     def decorate(f):
-        def handler(signum, frame):
+        def handler(signum, frame):# pylint:disable=unused-argument
             print("[angrop] Timeout")
             raise RopException("[angrop] Timeout!")
         def new_f(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     packages=['angrop'],
     install_requires=[
         'progressbar',
+        'tqdm',
         'angr==9.0.gitrolling',
     ],
 )

--- a/tests/test_rop.py
+++ b/tests/test_rop.py
@@ -180,8 +180,14 @@ def test_roptest_x86_64():
 
     # verifying this is a giant pain, partially because the binary is so tiny, and there's no code beyond the syscall
     assert len(c._gadgets) == 8
-    # this is the hardcoded chain...
-    assert [ g.addr for g in c._gadgets ] == [ 0x4000b0, 0x4000b2, 0x4000b4, 0x4000b0, 0x4000bb, 0x4000b2, 0x4000bf, 0x4000c1 ]
+
+    # verify the chain is valid
+    chain_addrs = [ g.addr for g in c._gadgets ]
+    assert chain_addrs[1] in [0x4000b2, 0x4000bd]
+    assert chain_addrs[5] in [0x4000b2, 0x4000bd]
+    chain_addrs[1] = 0x4000b2
+    chain_addrs[5] = 0x4000b2
+    assert chain_addrs == [ 0x4000b0, 0x4000b2, 0x4000b4, 0x4000b0, 0x4000bb, 0x4000b2, 0x4000bf, 0x4000c1 ]
 
 def run_all():
     functions = globals()


### PR DESCRIPTION
many changes:
1. generate ropchain in a  generator manner instead of finding the "best" gadget. This allows us to handle cases where the "best" gadgets are conflict with each other and fail the longer chain generation. For example, memory setter relies on using register setters for several times. It's possible that the "best" register setters do not work. In those cases, finding the second best gadget may resolve the issue
2. support JOP in primitive way
3. clean up the code for a bit
4. add timeout mechanisms in gadget analyzer to prevent hangs during gadget analysis.
5. angrop does not handle conditional execution in arm properly, so we disable it at the moment.
