### PR TITLE
Unconstain angr dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ long_description_content_type = text/markdown
 
 [options]
 install_requires =
-    angr == 9.2.7.dev0
+    angr
     tqdm
 python_requires = >= 3.6
 packages = find:


### PR DESCRIPTION
We're removing angrop from the list of repos, so unconstraining it will allow it to continue to be able to be installed from source as part of an angr-dev setup.