### PR TITLE
Update mem_changer.py to address logic bug in add_to_mem.

### DIFF
--- a/angrop/chain_builder/mem_changer.py
+++ b/angrop/chain_builder/mem_changer.py
@@ -115,13 +115,13 @@ class MemChanger(Builder):
         l.debug("Now building the mem add chain")
 
         # try to build the chain
-        try:
-            for g in gadgets:
+        for g in gadgets:
+            try:
                 chain = self._add_mem_with_gadget(g, addr, data_size, difference=value)
                 self.verify(chain, addr, value, data_size)
                 return chain
-        except RopException:
-            pass
+            except RopException:
+                pass
 
         raise RopException("Fail to perform add_to_mem!")
 


### PR DESCRIPTION
Fixed logic error with a for loop in a try block, where each loop could raise an exception causing only the first gadget to ever be checked if the first gadget fails one of the checks.

Reference #81 