### PR TITLE
Adds support for utilizing gadgets with syscall preamble

### DIFF
--- a/angrop/chain_builder/sys_caller.py
+++ b/angrop/chain_builder/sys_caller.py
@@ -132,8 +132,15 @@ class SysCaller(FuncCaller):
         for gadget in self.syscall_gadgets:
             if needs_return and not gadget.can_return:
                 continue
+            #skip gadgets that have wrong preamble
+            if gadget.preamble != None and gadget.preamble != syscall_num: 
+                continue
             try:
-                return self._func_call(gadget, cc, args, extra_regs=extra_regs,
+                if gadget.preamble == syscall_num:
+                    return self._func_call(gadget, cc, args,
+                               needs_return=needs_return, **kwargs)
+                else:
+                    return self._func_call(gadget, cc, args, extra_regs=extra_regs,
                                needs_return=needs_return, **kwargs)
             except Exception: # pylint: disable=broad-exception-caught
                 continue

--- a/angrop/rop_gadget.py
+++ b/angrop/rop_gadget.py
@@ -293,6 +293,7 @@ class SyscallGadget(RopGadget):
         super().__init__(addr)
         self.makes_syscall = False
         self.starts_with_syscall = False
+        self.preamble = None
 
     def __str__(self):
         s = f"SyscallGadget {self.addr:#x}\n"
@@ -300,6 +301,7 @@ class SyscallGadget(RopGadget):
         s += f"  transit type: {self.transit_type}\n"
         s += f"  can return: {self.can_return}\n"
         s += f"  starts_with_syscall: {self.starts_with_syscall}\n"
+        s += f"  preamble: {self.preamble:#x}\n"
         return s
 
     def __repr__(self):
@@ -313,4 +315,5 @@ class SyscallGadget(RopGadget):
         new = super().copy()
         new.makes_syscall = self.makes_syscall
         new.starts_with_syscall = self.starts_with_syscall
+        new.preamble = self.preamble
         return new


### PR DESCRIPTION
There was TODO comment about utilizing syscalls with preamble. 

This was achieved by adding `preamble` attribute to SyscallGadget class, that is set to the syscall number if preamble is found and None otherwise.

I made use of _windup_to_presyscall_state, but I needed to change it to check if the final_state self.is_in_kernel returns True.