### PR TITLE
Fix logic error in _write_to_mem_with_gadget()

### DIFF
--- a/angrop/chain_builder/mem_writer.py
+++ b/angrop/chain_builder/mem_writer.py
@@ -263,7 +263,7 @@ class MemWriter(Builder):
             raise RopException("memory write fails")
         # the next pc must come from the stack
         if len(state.regs.pc.variables) != 1:
-            return False
+            raise RopException("must have only one pc variable")
         if not set(state.regs.pc.variables).pop().startswith("symbolic_stack"):
-            return False
+            raise RopException("the next pc not from the stack")
         return chain


### PR DESCRIPTION
`raise RopException` in `_write_to_mem_with_gadget()` when selected gadget does not pass the checks stating that the next pc must come from the stack rather than `return False`

`_write_to_mem_with_gadget` is called by `_try_write_to_mem` using the `chain += ` syntax

`_try_write_to_mem` is called in a try except block for each gadget in `_write_to_mem`.

The except block excepts the following exceptions: `RopException, angr.errors.SimEngineError, angr.errors.SimUnsatError`

Before this change, if the first gadget checked with this workflow did not pass the check, the try block would fail to perform `chain + False` on this line: https://github.com/angr/angrop/blob/5d44d31ec9272521e270606cccaf952faf237626/angrop/rop_chain.py#L33
with:
```
AttributeError: 'bool' object has no attribute '_blank_state'
```

Since `AttributeErrors` are not in the list of excepted errors, the next gadget is not tried.


Replacing the `return False` with  `raise RopException` fixes this issue and allows all of the gadgets to be tried until a working mem writer chain is found.