### PR TITLE
updated timeout to run in thread to fix unsafe exception handling

### DIFF
--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -1,5 +1,5 @@
-import time
-import signal
+import ctypes
+import threading
 
 import angr
 import claripy
@@ -309,24 +309,40 @@ def step_to_unconstrained_successor(project, state, max_steps=2, allow_simproced
     except (angr.errors.AngrError, angr.errors.SimError) as e:
         raise RopException("Does not get to a single unconstrained successor") from e
 
+class ThreadWithReturnValue(threading.Thread):
+    def __init__(self, group=None, target=None, name=None,
+                 args=(), kwargs={}):
+        threading.Thread.__init__(self, group, target, name, args, kwargs)
+        self._return = None
+    def run(self):
+        if self._target is not None:
+            try:
+                self._return = self._target(*self._args, **self._kwargs)
+            except RopException:
+                self._return = None
+    def join(self, *args, **kwargs):
+        threading.Thread.join(self, *args, **kwargs)
+        return self._return
+
+
 def timeout(seconds_before_timeout):
     def decorate(f):
-        def handler(signum, frame):# pylint:disable=unused-argument
-            print("[angrop] Timeout")
-            raise RopException("[angrop] Timeout!")
         def new_f(*args, **kwargs):
-            old = signal.signal(signal.SIGALRM, handler)
-            old_time_left = signal.alarm(seconds_before_timeout)
-            if 0 < old_time_left < seconds_before_timeout: # never lengthen existing timer
-                signal.alarm(old_time_left)
-            start_time = time.time()
-            try:
+            if threading.current_thread().name.startswith("angrop_timeout_") or seconds_before_timeout == 0:
+                # We are already executing in an angrop timeout thread, no need to spin up another thread
                 result = f(*args, **kwargs)
-            finally:
-                if old_time_left > 0: # deduct f's run time from the saved timer
-                    old_time_left -= int(time.time() - start_time)
-                signal.signal(signal.SIGALRM, old)
-                signal.alarm(old_time_left)
+            else:
+                thread_name = f"angrop_timeout_{seconds_before_timeout}s_{f.__name__}"
+                thread = ThreadWithReturnValue(target=f, name=thread_name, args=args, kwargs=kwargs)
+                thread.start()
+                result = thread.join(timeout=seconds_before_timeout)
+                exception_count = 0
+                while thread.is_alive():
+                    if exception_count == 0:
+                        print("[angrop] Timeout")
+                    exception_count += 1
+                    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(thread.ident), ctypes.py_object(RopException))
+                    result = thread.join(timeout=0.1)
             return result
         return new_f
     return decorate


### PR DESCRIPTION
When trying to make a chain for a specific binary, we 100% reliably get this exception:

```
[angrop] Timeout
Exception ignored in: <function AstRef.__del__ at 0x7ffff41f5090>
Traceback (most recent call last):
  File "/dev/shm/.venv/lib/python3.10/site-packages/z3/z3.py", line 352, in __del__
    Z3_dec_ref(self.ctx.ref(), self.as_ast())
  File "/dev/shm/.venv/lib/python3.10/site-packages/z3/z3core.py", line 1542, in Z3_dec_ref
    def Z3_dec_ref(a0, a1, _elems=Elementaries(_lib.Z3_dec_ref)):
  File "/dev/shm/.venv/lib/python3.10/site-packages/angrop/rop_utils.py", line 312, in handler
    raise RopException("[angrop] Timeout!")
angrop.errors.RopException: [angrop] Timeout!
```

This is an angrop timeout which is interrupting some z3 code to throw an exception.

What's specifically happening here is that the z3 code that's being interrupted to inject a RopException is a `__del__` method.

Here's an excerpt from: `https://docs.python.org/3/reference/datamodel.html#object.__del__`
```
Warning
Due to the precarious circumstances under which __del__() methods are invoked, exceptions that occur during their execution are ignored, and a warning is printed to sys.stderr instead.
```

According to Python documentation, when an Exception is raised under a `__del__` method, the Exception is ignored and execution continues.

So, in our specific scenario, the timeout fails and analysis continues until you run out of RAM and the OOM Killer kills your python process.

I've included a script called orig_timeout.py to demonstrate this. The script calls busy_function() which takes about 3 seconds to run. I copied the angrop timeout decorator into the script and forced the busy_function to have a 1 second timeout. You can see from running the script that busy_function() receives the timeout exception at the 1 second mark, but since it's executing a `__del__` method, the exception is ignored and busy_function continues executing until it is finished.
```
Running 1/5
Running 2/5
[angrop] Timeout
Exception ignored in: <function FakeZ3.__del__ at 0x7ffff731a5f0>
Traceback (most recent call last):
  File "orig_timeout.py", line 34, in __del__
    time.sleep(0.5)
  File "orig_timeout.py", line 13, in handler
    raise RopException("[angrop] Timeout!")
__main__.RopException: [angrop] Timeout!
Running 3/5
Running 4/5
Running 5/5
The timeout-decorated function took 2.906207323074341 seconds to execute.
```

I've also included another script called new_timeout.py. This is a proposed new timeout solution. It kicks off the decorated function in a thread. When the timeout fires, a RopException is remotely raised in the target thread. If the target thread is currently executing a `__del__` method, the exception will be ignored (can't get around this behavior). However, we can see the thread is still running, so the timeout decorator will send RopExceptions to the target thread every 100ms until the exception takes effect in the target thread.
```
Running 1/5
Running 2/5
[angrop] Timeout
Exception ignored in: <function FakeZ3.__del__ at 0x7ffff7341ea0>
Traceback (most recent call last):
  File "new_timeout.py", line 51, in __del__
    time.sleep(0.5)
__main__.RopException:
The timeout-decorated function took 1.2032785415649414 seconds to execute.
```

[py_files.zip](https://github.com/angr/angrop/files/15211434/py_files.zip)

