### PR TITLE
Improve initial state. 

### DIFF
--- a/angrop/gadget_finder/gadget_analyzer.py
+++ b/angrop/gadget_finder/gadget_analyzer.py
@@ -35,7 +35,8 @@ class GadgetAnalyzer:
         else:
             extra_reg_set = None
         self._state = rop_utils.make_symbolic_state(self.project, sym_reg_set,
-                                                    extra_reg_set=extra_reg_set, stack_gsize=stack_gsize)
+                                                    extra_reg_set=extra_reg_set, stack_gsize=stack_gsize,
+                                                    fast_mode=self._fast_mode)
         self._concrete_sp = self._state.solver.eval(self._state.regs.sp)
 
     @rop_utils.timeout(3)


### PR DESCRIPTION
Use SpecialFillerMixin to improve reads of unmapped memory. Remove floating point support in fast mode. Store symbolic values in vex regs so a new symbolic value isn't created on those reads