### PR TITLE
Remove check for claripy.fp.FPV type

### DIFF
--- a/angrop/gadget_finder/gadget_analyzer.py
+++ b/angrop/gadget_finder/gadget_analyzer.py
@@ -776,7 +776,7 @@ class GadgetAnalyzer:
                 continue
 
             # we don't like floating point stuff
-            if isinstance(a.data.ast, (claripy.fp.FPV, claripy.ast.FP)):
+            if isinstance(a.data.ast, (claripy.ast.FP)):
                 continue
 
             # ignore read/write on stack after pivot


### PR DESCRIPTION
This type is internal to claripy, if it ever gets returned to angrop something is very broken.