### PR TITLE
handle bad bytes in memory write with xor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.egg-info
 dist
+build

--- a/angrop/chain_builder/__init__.py
+++ b/angrop/chain_builder/__init__.py
@@ -87,6 +87,18 @@ class ChainBuilder:
         value = rop_utils.cast_rop_value(value, self.project)
         return self._mem_changer.add_to_mem(addr, value, data_size=data_size)
 
+    def xor_mem(self, addr, value, data_size=None, preserve_regs=None):
+        """
+        :param addr: the address to xor
+        :param value: the value to xor with
+        :param data_size: the size of the data for the xor (defaults to project.arch.bits)
+        :param preserve_regs: set of registers to preserve, e.g. ('rax', 'rbx')
+        :return: A chain which will do [addr] ^= value
+        """
+        addr = rop_utils.cast_rop_value(addr, self.project)
+        value = rop_utils.cast_rop_value(value, self.project)
+        return self._mem_changer.xor_mem(addr, value, data_size=data_size, preserve_regs=preserve_regs)
+
     def write_to_mem(self, addr, data, fill_byte=b"\xff"):
         """
         :param addr: address to store the string


### PR DESCRIPTION
add a way to xor bytes in (which could be used in bad bytes)

e.g.
```python
bad_chars = {ord("x"), ord("g"), ord("a"), ord(".")}
data =     b"flag.txt"
new_data = b"flbhbtyt"
chain = rop.write_to_mem(bss, new_data)
for i in range(len(data)):
    if data[i] in bad_chars:
        chain += rop.xor_mem(bss + i, data[i] ^ new_data[i], data_size=8)
```