### PR TITLE
Fix: Cross-plat support issues in multi-threaded gadget discovery codepaths

### DIFF
--- a/angrop/gadget_finder/__init__.py
+++ b/angrop/gadget_finder/__init__.py
@@ -1,8 +1,10 @@
 import os
 import re
+import sys
 import time
 import signal
 import logging
+import threading
 import multiprocessing as mp
 from functools import partial
 
@@ -43,39 +45,72 @@ def _set_global_gadget_analyzer(rop_gadget_analyzer):
     process = psutil.Process()
     _global_init_rss = process.memory_info().rss
 
-def alarm_handler(signum, frame): # pylint: disable=unused-argument
-    l.warning("[angrop] worker_func2 times out, exit the worker process!")
-    os._exit(0)
-
 def worker_func1(cslice):
     analyzer = _global_gadget_analyzer
     res = list(GadgetFinder._addresses_from_slice(analyzer, cslice, _global_skip_cache, _global_cache, None))
     return (cslice[1]-cslice[0]+1, res)
 
-def worker_func2(addr, cond_br=None):
-    analyzer = _global_gadget_analyzer
-    signal.signal(signal.SIGALRM, alarm_handler)
-
-    signal.alarm(ANALYZE_GADGET_TIMEOUT)
-    if cond_br is None:
-        res = analyzer.analyze_gadget(addr)
-    else:
-        res = analyzer.analyze_gadget(addr, allow_conditional_branches=cond_br)
-    signal.alarm(0)
-
+def _maybe_exit_for_leak(res):
+    """Kill the worker process if RSS has grown past the leak threshold."""
     if not res:
-        # HACK: we are seeing some very bad memory leak situation, restart the worker
         process = psutil.Process()
         rss = process.memory_info().rss
-        if rss - _global_init_rss > 500*1024*1024:
+        if rss - _global_init_rss > 500*1024*1024: # type: ignore[operator]
             l.warning("[angrop] worker_func2 encounters memory leak, exit the worker process!")
             os._exit(0)
 
+def _normalize_gadget_result(res):
     if res is None:
         return []
     if isinstance(res, list):
         return res
     return [res]
+
+if sys.platform != "win32":
+    def alarm_handler(signum, frame): # pylint: disable=unused-argument
+        l.warning("[angrop] worker_func2 times out, exit the worker process!")
+        os._exit(0)
+
+    def worker_func2(addr, cond_br=None):
+        analyzer = _global_gadget_analyzer
+        signal.signal(signal.SIGALRM, alarm_handler)
+
+        signal.alarm(ANALYZE_GADGET_TIMEOUT)
+        if cond_br is None:
+            res = analyzer.analyze_gadget(addr)
+        else:
+            res = analyzer.analyze_gadget(addr, allow_conditional_branches=cond_br)
+        signal.alarm(0)
+
+        _maybe_exit_for_leak(res)
+        return _normalize_gadget_result(res)
+
+else:
+    # Windows lacks SIGALRM so replicate the kill the worker on timeout
+    # behaviour with a per-call watchdog thread that calls `os._exit(0)`
+    # if the analysis exceeds `ANALYZE_GADGET_TIMEOUT`. `mp.Pool` will
+    # then replace the dead worker, matching the POSIX behaviour.
+    def worker_func2(addr, cond_br=None):
+        analyzer = _global_gadget_analyzer
+        done = threading.Event()
+
+        def watchdog():
+            if not done.wait(ANALYZE_GADGET_TIMEOUT):
+                l.warning("[angrop] worker_func2 times out, exit the worker process!")
+                os._exit(0)
+
+        t = threading.Thread(target=watchdog, daemon=True)
+        t.start()
+        try:
+            if cond_br is None:
+                res = analyzer.analyze_gadget(addr)
+            else:
+                res = analyzer.analyze_gadget(addr, allow_conditional_branches=cond_br)
+        finally:
+            done.set()
+
+        _maybe_exit_for_leak(res)
+        return _normalize_gadget_result(res)
 
 class GadgetFinder:
     """

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -1,6 +1,8 @@
 import sys
 import time
 import signal
+import ctypes
+import threading
 
 import angr
 import claripy
@@ -461,41 +463,86 @@ transit_arr = ["pop_pc", "jmp_reg", "jmp_mem", None]
 def transit_num(g):
     return transit_arr.index(g.transit_type)
 
-def handler(signum, frame):# pylint:disable=unused-argument
-    # Exception during __del__ will be ignore
-    # so if we happen to hit a __del__, retry the alarm
-    # reference: https://docs.python.org/3/reference/datamodel.html#object.__del__
-    while frame.f_back:
-        filename = frame.f_code.co_filename
-        if frame.f_code.co_name == '__del__':
-            signal.setitimer(signal.ITIMER_REAL, 0.1, 0)
-            return
-        if filename.startswith(sys.base_prefix) and filename.endswith("/weakref.py"):
-            print("Delaying for 0.1s because of weakref.py")
-            signal.setitimer(signal.ITIMER_REAL, 0.1, 0)
-            return
-        frame = frame.f_back
-    raise RopTimeoutException("[angrop] Timeout!")
+if sys.platform != "win32":
+    def handler(signum, frame):# pylint:disable=unused-argument
+        # Exception during __del__ will be ignore
+        # so if we happen to hit a __del__, retry the alarm
+        # reference: https://docs.python.org/3/reference/datamodel.html#object.__del__
+        while frame.f_back:
+            filename = frame.f_code.co_filename
+            if frame.f_code.co_name == '__del__':
+                signal.setitimer(signal.ITIMER_REAL, 0.1, 0)
+                return
+            if filename.startswith(sys.base_prefix) and filename.endswith("/weakref.py"):
+                print("Delaying for 0.1s because of weakref.py")
+                signal.setitimer(signal.ITIMER_REAL, 0.1, 0)
+                return
+            frame = frame.f_back
+        raise RopTimeoutException("[angrop] Timeout!")
 
-def timeout(seconds_before_timeout):
-    def decorate(f):
-        def new_f(*args, **kwargs):
-            old = signal.getsignal(signal.SIGALRM)
-            old_time_left = 0
-            if old == handler:
-                old = signal.signal(signal.SIGALRM, handler)
-                old_time_left = signal.alarm(seconds_before_timeout)
-                if 0 < old_time_left < seconds_before_timeout: # never lengthen existing timer
-                    signal.alarm(old_time_left)
-            start_time = time.time()
-            try:
-                result = f(*args, **kwargs)
-            finally:
+    def timeout(seconds_before_timeout):
+        def decorate(f):
+            def new_f(*args, **kwargs):
+                old = signal.getsignal(signal.SIGALRM)
+                old_time_left = 0
                 if old == handler:
-                    if old_time_left > 0: # deduct f's run time from the saved timer
-                        old_time_left -= int(time.time() - start_time)
-                    signal.signal(signal.SIGALRM, old)
-                    signal.alarm(old_time_left)
-            return result
-        return new_f
-    return decorate
+                    old = signal.signal(signal.SIGALRM, handler)
+                    old_time_left = signal.alarm(seconds_before_timeout)
+                    if 0 < old_time_left < seconds_before_timeout: # never lengthen existing timer
+                        signal.alarm(old_time_left)
+                start_time = time.time()
+                try:
+                    result = f(*args, **kwargs)
+                finally:
+                    if old == handler:
+                        if old_time_left > 0: # deduct f's run time from the saved timer
+                            old_time_left -= int(time.time() - start_time)
+                        signal.signal(signal.SIGALRM, old)
+                        signal.alarm(old_time_left)
+                return result
+            return new_f
+        return decorate
+
+else:
+    # Windows lacks SIGALRM/setitimer. A watchdog thread waits for
+    # `seconds_before_timeout`; if `f` has not returned by then, the
+    # watchdog injects `RopTimeoutException` into the calling thread via
+    # `PyThreadState_SetAsyncExc`. The `__del__` / weakref delay logic
+    # from the POSIX handler is unnecessary here because async exceptions
+    # are delivered at bytecode boundaries rather than mid-finalizer?
+    def _async_raise(thread_ident, exc_type):
+        """
+        Inject `exc_type` into the thread with id `thread_ident`.
+        Returns True when exactly one thread was affected.
+        """
+        # here be dragons...
+        # https://docs.python.org/3/c-api/threads.html#c.PyThreadState_SetAsyncExc
+        res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+            ctypes.c_ulong(thread_ident), ctypes.py_object(exc_type)
+        )
+        if res > 1:
+            # More than one thread was affected; revert to avoid corrupting state.
+            ctypes.pythonapi.PyThreadState_SetAsyncExc(
+                ctypes.c_ulong(thread_ident), None
+            )
+        return res == 1
+
+    def timeout(seconds_before_timeout):
+        def decorate(f):
+            def new_f(*args, **kwargs):
+                target_ident = threading.get_ident()
+                done = threading.Event()
+
+                def watchdog():
+                    if done.wait(seconds_before_timeout):
+                        return  # f() finished within the budget
+                    _async_raise(target_ident, RopTimeoutException)
+
+                t = threading.Thread(target=watchdog, daemon=True)
+                t.start()
+                try:
+                    return f(*args, **kwargs)
+                finally:
+                    done.set()
+            return new_f
+        return decorate


### PR DESCRIPTION
per: issue https://github.com/angr/angrop/issues/155

some quick fixes for the use of POSIX-only signalling methods in the `rop_utils.timeout` decorator & `gadget_finder` `worker_func2` implementations. some caveats apply per commit descriptions:

### regarding fix 1 - https://github.com/pollingsoon/angrop/commit/eeb9fe8d1783b3dba6d5d14d8714ccbe97a8cba0

GIL-holding code can't be interrupted; `PyThreadState_SetAsyncExc` delivers the exception only at Python bytecode boundaries. A long syscall, e.g. time.sleep(), or a C extension that holds the GIL (possibly from within z3, claripy's solver calls or native unicorn execution, etc) will keep running until control returns to the Python interpreter. The timeout fires eventually rather than ASAP. On POSIX platforms, SIGALRM interrupts the syscall itself so this results in a suboptimal asymmetry here...

similarly, nested use of `@timeout` decorations on NT platform will not share the parent's remaining budget in this implementation in the same way the original POSIX code path does. Each subsequent level gets its own watchdog. Matching the SIGALRM nesting/accounting cross-platform would need substantially more bookkeeping and didn't seem worth it for the existing call sites (none are nested?).

### regarding fix 2 - https://github.com/pollingsoon/angrop/commit/de7b3d8981825728688b7d7aec025fed86545f5a 

each worker spawn re-imports angrop, re-imports angr, and re-runs _set_global_gadget_analyzer, etc. this is significantly slower than POSIX fork CoW behaviour but c'est la vie...