### PR TITLE
Add opt-in Intel IBT (endbr) transition-aware gadget support

### DIFF
--- a/angrop/arch.py
+++ b/angrop/arch.py
@@ -21,6 +21,23 @@ class ROPArch:
         self.execve_num = None
         self.sigreturn_num = None
 
+        # IBT (endbr) support; opt-in, x86/amd64 only. See ROP(ibt=/cet=/force_endbr=).
+        self.endbr_bytes = None
+        self.ibt = False
+        self.force_endbr = False
+
+    def addr_has_endbr(self, addr) -> bool:
+        """
+        Whether `addr` is an endbr (IBT landing pad) entry. Total: never raises.
+        """
+        if self.endbr_bytes is None:
+            return False
+        try:
+            raw = self.project.loader.memory.load(addr, len(self.endbr_bytes))
+        except Exception:  # pylint: disable=broad-except
+            return False
+        return bytes(raw) == self.endbr_bytes
+
     def _get_reg_list(self):
         """
         get the set of names of general-purpose registers + bp
@@ -51,6 +68,7 @@ class X86(ROPArch):
         self.segment_regs = {"cs", "ds", "es", "fs", "gs", "ss"}
         self.execve_num = 0xb
         self.sigreturn_num = 0x77
+        self.endbr_bytes = b"\xf3\x0f\x1e\xfb"  # endbr32
 
     def _x86_block_make_sense(self, block):
         capstr = str(block.capstone).lower()
@@ -91,6 +109,7 @@ class AMD64(X86):
         self.segment_regs = {"cs_seg", "ds_seg", "es_seg", "fs_seg", "gs_seg", "ss_seg"}
         self.execve_num = 0x3b
         self.sigreturn_num = 0xf
+        self.endbr_bytes = b"\xf3\x0f\x1e\xfa"  # endbr64
 
     def block_make_sense(self, block):
         return self._x86_block_make_sense(block)

--- a/angrop/chain_builder/builder.py
+++ b/angrop/chain_builder/builder.py
@@ -735,6 +735,11 @@ class Builder:
             # if final_gadget is passed in, then it is the shifter
             if final_gadget:
                 shifter = final_gadget
+                # Under IBT the jmp_mem gadget indirectly branches to the shifter, so the
+                # shifter must be endbr. The shifter is written into memory (not into
+                # _gadgets), so this is the ONLY place this transition can be enforced.
+                if self.arch.ibt and not shifter.has_endbr:
+                    return None
             else:
                 sc = abs(gadget.stack_change) + self.project.arch.bytes
                 shifter = None
@@ -747,6 +752,10 @@ class Builder:
                 shifter_list = itertools.chain.from_iterable(shifter_list)
                 for shifter in shifter_list:
                     if shifter.pc_offset < shift_size:
+                        continue
+                    # jmp_mem's indirect target is the shifter -> must be endbr under IBT.
+                    # Authoritative (not best-effort): the shifter never enters _gadgets.
+                    if self.arch.ibt and not shifter.has_endbr:
                         continue
                     if not shifter.changed_regs.intersection(post_preserve):
                         break

--- a/angrop/chain_builder/func_caller.py
+++ b/angrop/chain_builder/func_caller.py
@@ -202,6 +202,10 @@ class FuncCaller(Builder):
         func_gadget = FunctionGadget(address, symbol)
         func_gadget.stack_change = self.project.arch.bytes
         func_gadget.pc_offset = 0
+        # Synthesized gadgets never pass through _create_gadget, so tag has_endbr here;
+        # otherwise a jmp_reg -> func transition would be spuriously rejected under IBT.
+        if self.arch.ibt or self.arch.force_endbr:
+            func_gadget.has_endbr = self.arch.addr_has_endbr(address)
         try:
             return self._func_call(func_gadget, self._cc, args, **kwargs)
         except RopException:

--- a/angrop/chain_builder/reg_mover.py
+++ b/angrop/chain_builder/reg_mover.py
@@ -497,8 +497,13 @@ class RegMover(Builder):
                     assert gs
                     # FIXME: we are using the _build_reg_setting_chain API to turn mixin lists to a RopBlock
                     # which is pretty wrong
-                    chain = self._build_reg_setting_chain(gs, {})
-                    rb = RopBlock.from_chain(chain)
+                    try:
+                        chain = self._build_reg_setting_chain(gs, {})
+                        rb = RopBlock.from_chain(chain)
+                    except (RopException, SimUnsatError):
+                        # this candidate can't be built (e.g. an IBT-invalid jmp_reg
+                        # transition under ibt=True); skip it and try the next sequence
+                        continue
                     rop_blocks.add(rb)
             except nx.exception.NetworkXNoPath as e: # type: ignore
                 raise RopException(f"There is no chain can move {move.from_reg} to {move.to_reg}") from e

--- a/angrop/gadget_finder/__init__.py
+++ b/angrop/gadget_finder/__init__.py
@@ -118,7 +118,7 @@ class GadgetFinder:
     """
     def __init__(self, project, fast_mode=None, only_check_near_rets=True, max_block_size=None,
                  max_sym_mem_access=None, is_thumb=False, kernel_mode=False, stack_gsize=80,
-                 cond_br=False, max_bb_cnt=2):
+                 cond_br=False, max_bb_cnt=2, require_endbr=False, force_endbr=False):
         # configurations
         self.project = project
         self.fast_mode = fast_mode
@@ -128,6 +128,13 @@ class GadgetFinder:
         self.stack_gsize = stack_gsize
         self.cond_br = cond_br
         self.max_bb_cnt = max_bb_cnt
+
+        # IBT (endbr) awareness: only meaningful on architectures with an endbr encoding.
+        if (require_endbr or force_endbr) and self.arch.endbr_bytes is None:
+            l.warning("ibt/cet/force_endbr endbr tracking only applies to i386/amd64, disabling it")
+            require_endbr = force_endbr = False
+        self.arch.ibt = require_endbr
+        self.arch.force_endbr = force_endbr
 
         if only_check_near_rets and not isinstance(self.arch, (X86, AMD64, AARCH64)):
             l.warning("only_check_near_rets only makes sense for i386/amd64/aarch64, setting it to False")
@@ -381,6 +388,14 @@ class GadgetFinder:
             addr += offset # this is the actual address
 
             if addr in skip_addrs:
+                do_update()
+                continue
+
+            # force_endbr perf pre-filter: skip non-endbr entries before the cache lookup
+            # and the (expensive) block lift -- addr_has_endbr only needs a memory load.
+            # Correctness is guaranteed by the _analyze_gadget gate; this only saves work.
+            # Do NOT add to skip_cache/skip_addrs (those are keyed by block bytes / shared).
+            if analyzer.arch.force_endbr and not analyzer.arch.addr_has_endbr(addr):
                 do_update()
                 continue
 

--- a/angrop/gadget_finder/gadget_analyzer.py
+++ b/angrop/gadget_finder/gadget_analyzer.py
@@ -130,6 +130,11 @@ class GadgetAnalyzer:
     def _analyze_gadget(self, addr, allow_conditional_branches):
         l.info("Analyzing 0x%x", addr)
 
+        # force_endbr: blanket find-time exclusion of non-endbr entries. This is the ONLY
+        # place a gadget is dropped for IBT reasons; ibt alone never drops anything.
+        if self.arch.force_endbr and not self.arch.addr_has_endbr(addr):
+            return []
+
         # Step 1: first statically check if the block can reach stopping states
         #         static analysis is much faster
         if not self._can_reach_stopping_states(addr, allow_conditional_branches, max_steps=self._max_bb_cnt):
@@ -541,6 +546,10 @@ class GadgetAnalyzer:
             gadget = RopGadget(addr=addr)
 
         gadget = self._effect_analysis(gadget, init_state, final_state, ctrl_type, do_cond_branch)
+        if gadget is not None and (self.arch.ibt or self.arch.force_endbr):
+            # under force_endbr the _analyze_gadget gate already proved this addr is endbr,
+            # so skip the redundant memory load
+            gadget.has_endbr = True if self.arch.force_endbr else self.arch.addr_has_endbr(gadget.addr)
         return gadget
 
     def _analyze_concrete_regs(self, final_state, gadget):

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -1,3 +1,4 @@
+import re
 import pickle
 import inspect
 import logging
@@ -23,7 +24,7 @@ class ROP(Analysis):
 
     def __init__(self, only_check_near_rets=True, max_block_size=None, max_sym_mem_access=None,
                  fast_mode=None, rebase=None, is_thumb=False, kernel_mode=False, stack_gsize=80,
-                 cond_br=False, max_bb_cnt=2
+                 cond_br=False, max_bb_cnt=2, ibt=False, cet=None, force_endbr=False
                  ):
         """
         Initializes the rop gadget finder
@@ -39,8 +40,28 @@ class ROP(Analysis):
         :param stack_gsize: change the maximum allowable stack change for gadgets, where
                             the max stack_change = stack_gsize * arch.bytes
         :param cond_br: whether to support conditional branches, this option impacts gadget finding speed significantly
+        :param ibt: opt-in Intel IBT (endbr) awareness (x86/amd64 only). Tags every gadget with
+                    has_endbr and, at chain-build time, rejects indirect-branch transitions
+                    (jmp_reg / jmp_mem) that land on a non-endbr gadget. ret transitions are exempt.
+                    No gadget is dropped; default (off) behavior is byte-for-byte unchanged.
+        :param cet: alias/superset of ibt accepting a CET feature string; enables ibt when it
+                    names IBT, e.g. True, "ibt", "full", "ibt+shstk" (a bare "shstk" does not).
+        :param force_endbr: blanket find-time exclusion of every gadget whose entry is not an
+                            endbr landing pad (x86/amd64 only). Independent of ibt.
         :return:
         """
+        require_endbr = bool(ibt)
+        if isinstance(cet, str):
+            tokens = [t for t in re.split(r'[\s,+|]+', cet.strip().lower()) if t]
+            if 'ibt' in tokens or 'full' in tokens:
+                require_endbr = True
+            # warn per unrecognized token, so a typo like "ibr+shstk" is caught even
+            # though the valid "shstk" co-occurs (otherwise IBT is silently left off).
+            for t in tokens:
+                if t not in ('ibt', 'full', 'shstk'):
+                    l.warning("unrecognized cet token %r in %r; expected 'ibt', 'full', 'shstk', or e.g. 'ibt+shstk'", t, cet)
+        elif cet:  # truthy non-string (True, or any truthy) -> enable IBT, never silently off
+            require_endbr = True
 
         # private list of RopGadget's
         self._all_gadgets: list[RopGadget] = [] # all types of gadgets
@@ -60,7 +81,8 @@ class ROP(Analysis):
         self.gadget_finder = GadgetFinder(self.project, fast_mode=fast_mode, only_check_near_rets=only_check_near_rets,
                                           max_block_size=max_block_size, max_sym_mem_access=max_sym_mem_access,
                                           is_thumb=is_thumb, kernel_mode=kernel_mode, stack_gsize=stack_gsize,
-                                          cond_br=cond_br, max_bb_cnt=max_bb_cnt)
+                                          cond_br=cond_br, max_bb_cnt=max_bb_cnt,
+                                          require_endbr=require_endbr, force_endbr=force_endbr)
         self.arch = self.gadget_finder.arch
 
         # chain builder
@@ -179,13 +201,41 @@ class ROP(Analysis):
         all_gadgets = self._all_gadgets
         for g in all_gadgets:
             g.project = None
-        return (all_gadgets, self._duplicates)
+        # record whether this cache was force_endbr-filtered so a mismatched load can warn
+        return (all_gadgets, self._duplicates, {'force_endbr': self.arch.force_endbr})
 
     def _load_cache_tuple(self, tup):
         self._all_gadgets = tup[0]
         self._duplicates = tup[1]
+        meta = tup[2] if len(tup) > 2 else {}  # older caches are 2-tuples
         for g in self._all_gadgets:
             g.project = self.project
+        # A force_endbr cache is a strict subset (non-endbr entries were dropped at save
+        # time and are NOT in the pickle), so loading it without force_endbr silently
+        # yields a reduced set that re-tagging cannot recover. Warn rather than mislead.
+        if meta.get('force_endbr', False) and not self.arch.force_endbr:
+            l.warning("loaded cache was saved with force_endbr=True; its gadget set is "
+                      "reduced to endbr entries and does not match a full find")
+        # cross-flag correctness: load_gadgets bypasses _analyze_gadget, so a cache saved
+        # under default flags carries has_endbr=False and was never force_endbr-filtered.
+        # Re-tag (and, for force_endbr, re-filter) here so the loaded set matches a fresh
+        # find. No-op when neither flag is set (C0).
+        if self.arch.force_endbr:
+            self._all_gadgets = [g for g in self._all_gadgets if self.arch.addr_has_endbr(g.addr)]
+            for g in self._all_gadgets:
+                g.has_endbr = True  # survivors are known endbr; no need to re-load
+            # keep _duplicates consistent with _all_gadgets: drop non-endbr equivalents so
+            # badbyte substitution in _screen_gadgets never selects a non-endbr address
+            # (which analyze_gadget would reject, silently dropping a buildable gadget)
+            filtered_dups = {}
+            for h, addrs in self._duplicates.items():
+                eqs = {a for a in addrs if self.arch.addr_has_endbr(a)}
+                if eqs:
+                    filtered_dups[h] = eqs
+            self._duplicates = filtered_dups
+        elif self.arch.ibt:
+            for g in self._all_gadgets:
+                g.has_endbr = self.arch.addr_has_endbr(g.addr)
         self._screen_gadgets()
 
     def save_gadgets(self, path):

--- a/angrop/rop_block.py
+++ b/angrop/rop_block.py
@@ -160,6 +160,7 @@ class RopBlock(RopChain, RopEffect):
             else:
                 raise NotImplementedError("plz create an issue")
         rb._analyze_effect()
+        rb._check_ibt_seq(rb._gadgets)  # the jmp_reg branch appends directly; validate it too
         return rb
 
     @staticmethod

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -77,6 +77,9 @@ class RopChain:
             if not result._blank_state.satisfiable():
                 raise RopException("cannot use a rop_block with different constraints yet")
 
+        # both operands are internally IBT-valid (every _gadgets write is validated), so
+        # only the new join seam needs checking -- avoids O(n^2) re-validation on a+b+c+...
+        result._check_ibt_seq(self._gadgets[-1:] + other._gadgets[:1])
         return result
 
     def set_timeout(self, timeout):
@@ -94,6 +97,11 @@ class RopChain:
         self.payload_len += self._p.arch.bytes
 
     def add_gadget(self, gadget):
+        # validate the new seam BEFORE any mutation, so a rejected transition leaves the
+        # chain untouched (add_value below would otherwise inflate _values/payload_len)
+        if self._gadgets:
+            self._check_ibt_seq([self._gadgets[-1], gadget])
+
         value = gadget.addr
         if self._pie:
             value -= self._p.loader.main_object.mapped_base
@@ -108,7 +116,30 @@ class RopChain:
         self._gadgets.append(gadget)
 
     def set_gadgets(self, gadgets: list[RopGadget]):
+        self._check_ibt_seq(gadgets)  # validate before mutating self
         self._gadgets = gadgets
+
+    def _check_ibt_seq(self, gadgets):
+        """
+        Under IBT (arch.ibt), reject indirect-branch transitions that land on a non-endbr
+        gadget. This is the centralized enforcement point for jmp_reg transitions: it runs
+        on every write to a chain's ordered gadget list. No-op unless arch.ibt is set (C0),
+        and no-op when the chain has no builder yet (e.g. freshly unpickled before
+        set_builder) so gadget-list writes keep working without a builder as they did
+        before IBT support.
+
+        Only jmp_reg's target is the adjacent _gadgets entry. jmp_mem's real target (the
+        shifter) lives in memory, not in _gadgets, and the following entry is reached via
+        the shifter's ret (exempt) -- jmp_mem is enforced in builder._normalize_jmp_mem.
+        pop_pc (ret) transitions are never checked (IBT exempts ret targets).
+        """
+        if self._builder is None or not self._builder.arch.ibt:
+            return
+        for prev, cur in zip(gadgets, gadgets[1:]):
+            if prev.transit_type == 'jmp_reg' and not cur.has_endbr:
+                raise RopException(
+                    "IBT violation: indirect branch from %#x lands on non-endbr gadget %#x"
+                    % (prev.addr, cur.addr))
 
     def add_constraint(self, cons):
         """

--- a/angrop/rop_gadget.py
+++ b/angrop/rop_gadget.py
@@ -24,6 +24,10 @@ class RopGadget(RopEffect):
         # for jmp_mem, where it jumps to
         self.pc_target = None # type: ignore
 
+        # IBT: whether the gadget's entry is an endbr landing pad. Only set (tagged) when
+        # ibt/force_endbr is enabled; stays False otherwise (and for non-x86 arches).
+        self.has_endbr = False
+
     @property
     def self_contained(self):
         """
@@ -104,6 +108,7 @@ class RopGadget(RopEffect):
         out.pc_offset = self.pc_offset
         out.pc_reg = self.pc_reg
         out.pc_target = self.pc_target
+        out.has_endbr = self.has_endbr
         return out
 
     def __getstate__(self):
@@ -113,6 +118,8 @@ class RopGadget(RopEffect):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        if 'has_endbr' not in self.__dict__:
+            self.has_endbr = False
 
 class PivotGadget(RopGadget):
     """

--- a/tests/test_find_gadgets.py
+++ b/tests/test_find_gadgets.py
@@ -349,6 +349,137 @@ def test_syscall_block_hash():
     for addr in [0x402de7, 0x425a00, 0x43e083, 0x4b146c]:
         assert addr in tasks
 
+def test_ibt_has_endbr_tagging():                         # C1
+    blob = b"\xf3\x0f\x1e\xfa\x5f\xc3\x5e\xc3"            # endbr64;pop rdi;ret | pop rsi;ret
+    proj = angr.load_shellcode(blob, "amd64", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    g_endbr = rop.analyze_gadget(0x400000)
+    g_plain = rop.analyze_gadget(0x400006)
+    assert g_endbr is not None and g_endbr.has_endbr is True
+    assert g_plain is not None and g_plain.has_endbr is False   # not filtered, tagged False
+
+
+def test_ibt_ret_gadgets_unaffected():                    # C2
+    proj = angr.load_shellcode(b"\x5f\xc3", "amd64", load_address=0x400000)  # pop rdi; ret
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    g = rop.analyze_gadget(0x400000)
+    assert g is not None and g.transit_type == 'pop_pc' and g.has_endbr is False
+
+
+def test_ibt_default_untagged():                          # C0.3
+    proj = angr.load_shellcode(b"\xf3\x0f\x1e\xfa\x5f\xc3", "amd64", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1)
+    g = rop.analyze_gadget(0x400000)
+    assert g is not None and g.has_endbr is False
+
+
+def test_ibt_check_transition():                          # C2 + C3 (via the mutator)
+    import pytest
+    from angrop.rop_chain import RopChain
+    from angrop.errors import RopException
+    proj = angr.load_shellcode(b"\xf3\x0f\x1e\xfa\x5f\xc3\x5e\xc3", "amd64", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    endbr_g = rop.analyze_gadget(0x400000)
+    plain_g = rop.analyze_gadget(0x400006)
+    plain_g.transit_type = 'jmp_reg'
+    chain = RopChain(rop.project, rop.chain_builder._reg_setter)
+    with pytest.raises(RopException):
+        chain.set_gadgets([plain_g, plain_g])             # jmp_reg -> non-endbr
+    chain.set_gadgets([plain_g, endbr_g])                 # jmp_reg -> endbr : ok
+    plain_g.transit_type = 'pop_pc'
+    chain.set_gadgets([plain_g, plain_g])                 # pop_pc -> non-endbr : ok (ret exempt)
+    plain_g.transit_type = 'jmp_mem'
+    chain.set_gadgets([plain_g, plain_g])                 # jmp_mem -> non-endbr : ok in mutator
+                                                          # (target is the in-memory shifter,
+                                                          #  enforced in _normalize_jmp_mem)
+
+
+def test_ibt_find_set_identity():                         # C0.2
+    proj = angr.Project(os.path.join(tests_dir, "i386", "bronze_ropchain"), auto_load_libs=False)
+    base = proj.analyses.ROP(); base.find_gadgets_single_threaded(show_progress=False)
+    ibt = proj.analyses.ROP(ibt=True); ibt.find_gadgets_single_threaded(show_progress=False)
+    assert {g.addr for g in base._all_gadgets} == {g.addr for g in ibt._all_gadgets}
+
+
+def test_ibt_cet_truth_table():                           # C6
+    proj = angr.load_shellcode(b"\x5f\xc3", "amd64", load_address=0x400000)
+    for kw in [dict(ibt=True), dict(cet=True), dict(cet="full"),
+               dict(cet="ibt"), dict(cet="ibt+shstk"), dict(cet="shstk+ibt"),
+               dict(cet=1)]:  # truthy non-True must not silently leave IBT off
+        assert proj.analyses.ROP(**kw).arch.ibt is True, kw
+    for kw in [dict(), dict(cet=None), dict(cet=False), dict(cet="shstk"),
+               dict(cet="ibr+shstk")]:  # typo of 'ibt' must NOT enable ibt (and warns)
+        assert proj.analyses.ROP(**kw).arch.ibt is False, kw
+
+
+def test_ibt_unpickled_chain_no_builder():                # F2: no crash without a builder
+    import pickle
+    from angrop.rop_chain import RopChain
+    proj = angr.load_shellcode(b"\xf3\x0f\x1e\xfa\x5f\xc3", "amd64", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    g = rop.analyze_gadget(0x400000)
+    chain = RopChain(rop.project, rop.chain_builder._reg_setter)
+    chain2 = pickle.loads(pickle.dumps(chain))            # __getstate__ nulls _builder
+    assert chain2._builder is None
+    chain2.set_gadgets([g, g])                            # must not raise despite ibt
+
+
+def test_ibt_pickle_survives(tmp_path):                   # C4
+    proj = angr.load_shellcode(b"\xf3\x0f\x1e\xfa\x5f\xc3", "amd64", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    rop.analyze_gadget(0x400000)
+    path = str(tmp_path / "cache"); rop.save_gadgets(path)
+    rop2 = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    rop2.load_gadgets(path, optimize=False)
+    assert any(g.has_endbr for g in rop2._all_gadgets)
+
+
+def test_ibt_cache_cross_flag(tmp_path):                  # C4 (cross-flag re-tag / re-filter)
+    blob = b"\xf3\x0f\x1e\xfa\x5f\xc3\x5e\xc3"            # endbr64;pop rdi;ret | pop rsi;ret
+    proj = angr.load_shellcode(blob, "amd64", load_address=0x400000)
+    base = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1)   # default: untagged
+    base.find_gadgets_single_threaded(show_progress=False)
+    path = str(tmp_path / "cache"); base.save_gadgets(path)
+    # load under ibt -> has_endbr re-tagged to match a fresh find (not left all-False)
+    ibt = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    ibt.load_gadgets(path, optimize=False)
+    tagged = {g.addr: g.has_endbr for g in ibt._all_gadgets}
+    assert tagged.get(0x400000) is True and tagged.get(0x400006) is False
+    # load under force_endbr -> non-endbr gadget re-filtered out of a default cache
+    fe = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, force_endbr=True)
+    fe.load_gadgets(path, optimize=False)
+    addrs = {g.addr for g in fe._all_gadgets}
+    assert 0x400000 in addrs and 0x400006 not in addrs
+    assert all(g.has_endbr for g in fe._all_gadgets)
+    # _duplicates stays consistent with _all_gadgets (no non-endbr equivalents left)
+    assert all(fe.arch.addr_has_endbr(a) for eqs in fe._duplicates.values() for a in eqs)
+
+
+def test_ibt_non_x86_noop():                              # C5
+    proj = angr.load_shellcode(b"\x1e\xff\x2f\xe1", "armel", load_address=0x1000)  # bx lr
+    assert proj.analyses.ROP(ibt=True).arch.ibt is False
+
+
+def test_ibt_endbr32_tagging():                           # C1 (endbr32 mirror)
+    blob = b"\xf3\x0f\x1e\xfb\x58\xc3"                    # endbr32; pop eax; ret
+    proj = angr.load_shellcode(blob, "x86", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, ibt=True)
+    g = rop.analyze_gadget(0x400000)
+    assert g is not None and g.has_endbr is True
+
+
+def test_force_endbr_excludes_non_endbr():                # C7
+    blob = b"\xf3\x0f\x1e\xfa\x5f\xc3\x5e\xc3"            # endbr64;pop rdi;ret | pop rsi;ret
+    proj = angr.load_shellcode(blob, "amd64", load_address=0x400000)
+    rop = proj.analyses.ROP(fast_mode=False, max_sym_mem_access=1, force_endbr=True)
+    assert rop.analyze_gadget(0x400000) is not None       # endbr kept
+    assert rop.analyze_gadget(0x400006) is None           # non-endbr dropped
+    rop.find_gadgets_single_threaded(show_progress=False)
+    addrs = {g.addr for g in rop._all_gadgets}
+    assert 0x400000 in addrs and 0x400006 not in addrs
+    assert all(g.has_endbr for g in rop._all_gadgets)
+
+
 def run_all():
     functions = globals()
     all_functions = {x:y for x, y in functions.items() if x.startswith('test_')}


### PR DESCRIPTION
## Summary

This adds optional awareness of Intel **IBT (Indirect Branch Tracking)** to angrop, so that on IBT-enabled x86/amd64 binaries it can (a) tag each gadget with whether its entry is an `endbr` landing pad and (b) refuse to build chains whose indirect-branch transitions land on a non-`endbr` gadget. It is **opt-in and off by default** — with the new flags unset, behaviour is byte-for-byte unchanged.

Under IBT, an indirect `jmp`/`call` may only transfer control to an `endbr32`/`endbr64` instruction; `ret` is unaffected (that is the shadow stack's concern). angrop currently ignores this, so it can hand back a chain that would fault (`#CP`) on an IBT-hardened target. This PR lets callers model that constraint.

## API

Three new, independent keyword arguments on `ROP(...)`, all defaulting to the existing behaviour:

- **`ibt=True`** (or `cet="ibt"` / `cet="ibt+shstk"` / `cet=True`) — *transition-aware* mode. Every gadget is tagged with `has_endbr`; **nothing is dropped**. At chain-build time a transition from a `jmp_reg`/`jmp_mem` gadget onto a non-`endbr` gadget is rejected. `ret` (`pop_pc`) transitions are never checked.
- **`force_endbr=True`** — *find-time exclusion*. Every gadget whose entry is not an `endbr` pad is dropped during gadget finding. Useful for reasoning about purely indirect-branch-driven (JOP/COP-style) chains. Independent of `ibt`.
- **`cet=`** accepts a CET feature string and enables `ibt` when it names IBT (`"ibt"`, `"full"`, `"ibt+shstk"`, …); a bare `"shstk"` does not.

Both flags are x86/amd64 only; on other architectures they emit a warning and disable themselves.

## Design

- **Opt-in, never auto-detected.** IBT enforcement keys only on the explicit flags, not on the binary's `.note.gnu.property` (`GNU_PROPERTY_X86_FEATURE_1_AND`) — so a default `ROP(binary)` on a `-fcf-protection` binary is completely unchanged.
- **Enforcement location.** For `jmp_reg` the branch target is the next gadget in the chain's ordered list, so the check lives in the `RopChain` gadget-list mutators (`set_gadgets` / `add_gadget` / `__add__`) plus the one direct-append site in `RopBlock.from_gadget_list` — i.e. every place the list is written — so no builder can assemble a bypassing chain. For `jmp_mem` the real target is the *shifter*, which `_normalize_jmp_mem` writes into memory and never appends to the gadget list, so that transition is enforced in the builder (a non-`endbr` shifter is simply not selected).
- `has_endbr` survives gadget caching (`save_gadgets` / `load_gadgets`) and is re-derived on load, so a cache saved without the flags is still correct when loaded with them.

## Backward compatibility

With `ibt=False, cet=None, force_endbr=False` (the defaults): no gadget is tagged or dropped, every enforcement hook returns on its first line, and the discovered gadget set is identical. The full existing test suite passes unchanged.

## Testing

- New unit tests in `tests/test_find_gadgets.py`: `has_endbr` tagging (endbr64 + endbr32), `ret`-exemption, mutator enforcement (reject `jmp_reg`→non-endbr / allow →endbr / exempt `pop_pc` and `jmp_mem`), the `cet` truth table, cache round-trip + cross-flag re-tag/re-filter, `force_endbr` exclusion, non-x86 no-op, and default-vs-`ibt` find-set identity.
- Exercised on real binaries: a CET-compiled glibc (`endbr` present → exact tagging; `force_endbr` isolates precisely the endbr-entry set; `set_regs` builds an IBT-clean chain) and a 66 MB kernel image built without kernel-IBT (0 `endbr`, handled cleanly with no crash).

## Out of scope

- Integrating IBT into gadget *selection* (e.g. preferring `endbr` candidates in `reg_setter`'s `jmp_reg` normalisation). Enforcement here is post-hoc rejection, which is sound — it never emits an invalid chain — but can in principle fail to find an IBT-valid `jmp_reg` chain when a non-`endbr` candidate is tried first. Register setting overwhelmingly uses `ret` gadgets, so the practical impact is minimal; this is a natural follow-up.
- Shadow-stack (`shstk`) modelling and JOP/COP chain building are not part of this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
