### PR TITLE
Import claripy through the angr package

### DIFF
--- a/angrop/chain_builder/builder.py
+++ b/angrop/chain_builder/builder.py
@@ -8,7 +8,7 @@ from functools import cmp_to_key
 from collections import defaultdict
 
 import angr
-import claripy
+from angr import claripy
 
 from .. import rop_utils
 from ..errors import RopException

--- a/angrop/chain_builder/builder.py
+++ b/angrop/chain_builder/builder.py
@@ -185,7 +185,7 @@ class Builder:
             var_map[reg] = (old_var, new_var)
 
         #  if this ast is a tree, record all the children_asts
-        for x in ast.children_asts():
+        for x in rop_utils.children_asts(ast):
             if x.op != 'BVS':
                 continue
             name = x.args[0]
@@ -210,7 +210,7 @@ class Builder:
         if ast.op == 'BVS':
             variables.add(ast)
         else:
-            for x in ast.children_asts():
+            for x in rop_utils.children_asts(ast):
                 if x.op != 'BVS':
                     continue
                 variables.add(x)
@@ -252,7 +252,7 @@ class Builder:
         # in some cases, we can just solve it
         if mode == 'stack' and lhs.symbolic and not rhs.symbolic and len(lhs.variables) == 1 and lhs.depth > 1:
             target_ast = None
-            for ast in lhs.children_asts():
+            for ast in rop_utils.children_asts(lhs):
                 if ast.op == 'BVS' and ast.args[0].startswith('symbolic_stack'):
                     target_ast = ast
                     break

--- a/angrop/chain_builder/func_caller.py
+++ b/angrop/chain_builder/func_caller.py
@@ -2,7 +2,7 @@ import struct
 import logging
 
 import angr
-import claripy
+from angr import claripy
 from angr.calling_conventions import SimRegArg, SimStackArg
 
 from .builder import Builder

--- a/angrop/chain_builder/mem_writer.py
+++ b/angrop/chain_builder/mem_writer.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 
 import angr
-import claripy
+from angr import claripy
 
 from .builder import Builder
 from .. import rop_utils

--- a/angrop/chain_builder/mem_writer.py
+++ b/angrop/chain_builder/mem_writer.py
@@ -101,7 +101,7 @@ class MemWriteChain:
             if not val.symbolic or not val.ast.variables:
                 continue
             if list(val.ast.variables)[0].startswith('addr_'):
-                test_ast = claripy.algorithm.replace(expr=val.ast,
+                test_ast = claripy.replace(expr=val.ast,
                                           old=self.addr_bv,
                                           new=addr_val.data)
                 new = addr_val.copy()
@@ -112,7 +112,7 @@ class MemWriteChain:
                 continue
             if list(val.ast.variables)[0].startswith('data_'):
                 var = claripy.BVV(struct.unpack(fmt, data.ljust(arch_bytes, b'\x00'))[0], len(self.data_bv))
-                test_ast = claripy.algorithm.replace(expr=val.ast,
+                test_ast = claripy.replace(expr=val.ast,
                                           old=self.data_bv,
                                           new=var)
                 if len(test_ast) < arch_bits: # type: ignore

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict, Counter
 from functools import cmp_to_key
 
-import claripy
+from angr import claripy
 import networkx as nx
 from angr.errors import SimUnsatError
 

--- a/angrop/chain_builder/reg_setter.py
+++ b/angrop/chain_builder/reg_setter.py
@@ -66,7 +66,7 @@ class ConcreteRegChanger(Builder):
     def _effect_tuple(self, g):
         reg = list(g.concrete_reg_changes.keys())[0]
         init_ast, final_ast = g.concrete_reg_changes[reg]
-        val = claripy.algorithm.replace(expr=final_ast,
+        val = claripy.replace(expr=final_ast,
                                         old=init_ast,
                                         new=claripy.BVV(0, self.project.arch.bits))
         op = final_ast.op
@@ -707,7 +707,7 @@ class RegSetter(Builder):
         for g1 in concrete_setter_gadgets:
             for g2 in delta_gadgets:
                 init_ast, final_ast = g2.concrete_reg_changes[reg]
-                ast = claripy.algorithm.replace(expr=final_ast,
+                ast = claripy.replace(expr=final_ast,
                                                 old=init_ast,
                                                 new=claripy.BVV(g1.concrete_regs[reg], arch_bits))
                 if ast.concrete_value != val.concreted:

--- a/angrop/chain_builder/shifter.py
+++ b/angrop/chain_builder/shifter.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 
-import claripy
+from angr import claripy
 
 from .. import rop_utils
 from .builder import Builder

--- a/angrop/gadget_finder/gadget_analyzer.py
+++ b/angrop/gadget_finder/gadget_analyzer.py
@@ -105,7 +105,7 @@ class GadgetAnalyzer:
             simgr.move(from_stash='active', to_stash='syscall',
                        filter_func=lambda s: rop_utils.is_in_kernel(self.project, s))
 
-        except (claripy.ClaripySolverInterruptError, claripy.errors.ClaripyZ3Error, ValueError): # type: ignore
+        except (claripy.ClaripySolverInterruptError, claripy.errors.ClaripyError, ValueError): # type: ignore
             return [], []
         except (claripy.ClaripyFrontendError,
                 angr.engines.vex.claripy.ccall.CCallMultivaluedException) as e: # type: ignore
@@ -170,7 +170,7 @@ class GadgetAnalyzer:
             except RopException as e:
                 l.debug("... %s", e)
                 continue
-            except (claripy.ClaripySolverInterruptError, claripy.errors.ClaripyZ3Error, ValueError): # type: ignore
+            except (claripy.ClaripySolverInterruptError, claripy.errors.ClaripyError, ValueError): # type: ignore
                 continue
             except (claripy.ClaripyFrontendError,
                     angr.engines.vex.claripy.ccall.CCallMultivaluedException) as e: # type: ignore
@@ -621,7 +621,7 @@ class GadgetAnalyzer:
             final_reg = final_state.registers.load(reg)
             if init_reg is final_reg:
                 continue
-            ast = claripy.algorithm.replace(expr=final_reg, old=init_reg, new=claripy.BVV(0, arch_bits))
+            ast = claripy.replace(expr=final_reg, old=init_reg, new=claripy.BVV(0, arch_bits))
             if ast.symbolic:
                 continue
             gadget.concrete_reg_changes[reg] = (init_reg, final_reg)

--- a/angrop/gadget_finder/gadget_analyzer.py
+++ b/angrop/gadget_finder/gadget_analyzer.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import angr
 import pyvex
-import claripy
+from angr import claripy
 from angr.analyses.bindiff import differing_constants
 from angr.analyses.bindiff import UnmatchedStatementsException
 from angr.errors import SimEngineError, SimMemoryError

--- a/angrop/gadget_finder/gadget_analyzer.py
+++ b/angrop/gadget_finder/gadget_analyzer.py
@@ -1015,6 +1015,14 @@ class GadgetAnalyzer:
                 return None
         data_stack_controllers = {x for x in sym_data.variables if x.startswith('symbolic_stack')}
 
+        # a memory change whose delta has no controller is a pure constant change (e.g. `dec [rax]`).
+        # we only recognize such constant changes at full word granularity. sub-word constant changes
+        # (e.g. thumb `ldrh; subs; strh`) are not usable by the mem-change chain builder; historically
+        # they were filtered out incidentally because claripy left the store data wrapped in an
+        # Extract, but clarirs simplifies that away, so we reject them explicitly here.
+        if not data_controllers and not data_stack_controllers:
+            if write_action.data.ast.size() != self.project.arch.bits:
+                return None
 
         mem_change = self._build_mem_access(read_action, gadget, init_state, final_state)
         mem_change.op = write_action.data.ast.op

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import inspect
 import logging
@@ -193,6 +194,7 @@ class ROP(Analysis):
         Saves gadgets in a file.
         :param path: A path for a file where the gadgets are stored
         """
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
         with open(path, "wb") as f:
             pickle.dump(self._get_cache_tuple(), f)
         for g in self._all_gadgets:

--- a/angrop/rop_chain.py
+++ b/angrop/rop_chain.py
@@ -268,7 +268,14 @@ class RopChain:
                 solver_state.solver.add(expr)
                 if not solver_state.solver.satisfiable():
                     raise RopException("bad chain!")
-            concrete_vals.append((solver_state.solver.eval(ast), value.rebase))
+            concrete = solver_state.solver.eval(ast)
+            # pin the concretized value so that values sharing constraints with this
+            # one (e.g. two registers tied by `r12 + rbx*8 == ptr`) are concretized
+            # consistently. without this, each eval() may pick a different satisfying
+            # model and the concrete values won't jointly satisfy the constraints.
+            if ast.symbolic:
+                solver_state.solver.add(ast == concrete)
+            concrete_vals.append((concrete, value.rebase))
 
         return concrete_vals
 

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -11,6 +11,25 @@ from angr.engines.successors import SimSuccessors
 from .errors import RegNotFoundException, RopException, RopTimeoutException
 from .rop_value import RopValue
 
+
+def children_asts(ast):
+    """
+    Iterate over the nested children ASTs of ``ast`` (depth-first).
+
+    Replaces claripy's ``Base.children_asts()``, which clarirs does not
+    provide; clarirs ASTs only expose their immediate ``.args``.
+    """
+    queue = [iter(ast.args)]
+    while queue:
+        try:
+            child = next(queue[-1])
+        except StopIteration:
+            queue.pop()
+            continue
+        if isinstance(child, claripy.ast.Base):
+            queue.append(iter(child.args))
+            yield child
+
 def addr_to_asmstring(project, addr):
     block = project.factory.block(addr)
     return "; ".join(["%s %s" %(i.mnemonic, i.op_str) for i in block.capstone.insns])
@@ -83,7 +102,7 @@ def get_ast_controllers(state, ast, reg_deps) -> set:
             if not state.registers.load(r).symbolic:
                 continue
             reg_sym_val = state.registers.load(r)
-            test_ast = claripy.algorithm.replace(expr=test_ast,
+            test_ast = claripy.replace(expr=test_ast,
                                       old=reg_sym_val,
                                       new=claripy.BVV(test_val, reg_sym_val.size()))
         # we consider 32-bit control on 64-bit system valid
@@ -111,7 +130,7 @@ def get_ast_const_offset(state, ast, reg_deps) -> int:
     # This is faster than eval with extra contraints
     for reg in reg_deps:
         reg_val = state.registers.load(reg)
-        ast = claripy.algorithm.replace(
+        ast = claripy.replace(
             expr=ast, old=reg_val, new=zero_val)
 
     assert not ast.symbolic
@@ -178,7 +197,7 @@ def fast_unconstrained_check(state, ast):
 
     passes_prefilter = True
 
-    for a in ast.children_asts():
+    for a in children_asts(ast):
         if a.op not in good_ops:
             passes_prefilter = False
         # check for x __add__ x which is constrained
@@ -255,7 +274,7 @@ def get_reg_name(arch, reg_offset):
 def bits_extended(ast):
     if ast.op in ('ZeroExt', 'SignExt'):
         return ast.args[0]
-    for c in ast.children_asts():
+    for c in children_asts(ast):
         if c.op in ('ZeroExt', 'SignExt'):
             return c.args[0]
     return None
@@ -296,10 +315,14 @@ def make_initial_state(project, stack_gsize):
     initial_state.options.discard(angr.options.CGC_ZERO_FILL_UNCONSTRAINED_MEMORY)
     initial_state.options.update({angr.options.TRACK_REGISTER_ACTIONS, angr.options.TRACK_MEMORY_ACTIONS,
                                   angr.options.TRACK_JMP_ACTIONS, angr.options.TRACK_CONSTRAINT_ACTIONS})
-    symbolic_stack = claripy.Concat(*[
-        initial_state.solver.BVS(f"symbolic_stack_{i}", project.arch.bits) for i in range(stack_gsize)
-    ])
-    initial_state.memory.store(initial_state.regs.sp, symbolic_stack)
+    # stack_gsize may be 0 (a gadget that controls no stack); skip the store in
+    # that case. claripy tolerated claripy.Concat() with no arguments, but
+    # clarirs rejects an empty operand list.
+    if stack_gsize > 0:
+        symbolic_stack = claripy.Concat(*[
+            initial_state.solver.BVS(f"symbolic_stack_{i}", project.arch.bits) for i in range(stack_gsize)
+        ])
+        initial_state.memory.store(initial_state.regs.sp, symbolic_stack)
     if initial_state.arch.bp_offset != initial_state.arch.sp_offset:
         initial_state.regs.bp = initial_state.regs.sp + 20*initial_state.arch.bytes
     initial_state.solver._solver.timeout = 1000  # only solve for a second at most

--- a/angrop/rop_utils.py
+++ b/angrop/rop_utils.py
@@ -5,7 +5,7 @@ import ctypes
 import threading
 
 import angr
-import claripy
+from angr import claripy
 from angr.engines.successors import SimSuccessors
 
 from .errors import RegNotFoundException, RopException, RopTimeoutException

--- a/angrop/rop_value.py
+++ b/angrop/rop_value.py
@@ -1,4 +1,4 @@
-import claripy
+from angr import claripy
 
 class RopValue:
     """

--- a/tests/test_badbytes.py
+++ b/tests/test_badbytes.py
@@ -36,7 +36,7 @@ def test_badbyte():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     # make sure it can set 0 first
@@ -91,7 +91,7 @@ def test_badbyte_transform():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.set_badbytes([0x00, 0x0A])
@@ -111,7 +111,7 @@ def test_badbyte_multibyte():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.set_badbytes([0x00, 0x0A])
@@ -133,7 +133,7 @@ def test_hard_regs_loop():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.set_badbytes([0x00, 0x0A])

--- a/tests/test_chainbuilder.py
+++ b/tests/test_chainbuilder.py
@@ -1,6 +1,6 @@
 import os
 
-import claripy
+from angr import claripy
 
 import angr
 import angrop # pylint: disable=unused-import

--- a/tests/test_chainbuilder.py
+++ b/tests/test_chainbuilder.py
@@ -19,7 +19,7 @@ def test_symbolic_data():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     var1 = claripy.BVS("var1", proj.arch.bits)
@@ -38,7 +38,7 @@ def test_x86_64_func_call():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.func_call('puts', [0x402704]) + rop.func_call('puts', [0x402704])
@@ -53,7 +53,7 @@ def test_i386_func_call():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.func_call('write', [1, 0x80AC5E8, 17]) + rop.func_call('write', [1, 0x80AC5E8, 17])
@@ -67,7 +67,7 @@ def test_arm_func_call():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.set_regs(lr=0x41414141)
@@ -95,7 +95,7 @@ def test_i386_syscall():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.do_syscall(4, [1, 0x80AC5E8, 17])
@@ -110,7 +110,7 @@ def test_x86_64_syscall():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     gadget = rop.analyze_gadget(0x4fb4a6)
@@ -136,7 +136,7 @@ def test_preserve_regs():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain1 = rop.set_regs(rdi=0x402715)
@@ -153,7 +153,7 @@ def test_i386_mem_write():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.write_to_mem(0xdeadbeef, b"/bin/sh\x00")
@@ -170,7 +170,7 @@ def test_ropvalue():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.write_to_mem(0x800000, b"/bin/sh\x00")
@@ -194,7 +194,7 @@ def test_reg_move():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     # test single register move
@@ -218,7 +218,7 @@ def test_set_regs():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.set_regs(r4=0x4141412c, r5=0x42424242)
@@ -234,7 +234,7 @@ def test_add_to_mem():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.write_to_mem(0xdeadbeef, b'CCCC') # 0x43434343
@@ -254,7 +254,7 @@ def test_add_to_mem():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.add_to_mem(0x41414140, 0x42424242)
@@ -266,7 +266,7 @@ def test_add_to_mem():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.add_to_mem(0x41414140, 0x42424242)
@@ -279,7 +279,7 @@ def test_pivot():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.pivot(0x41414140)
@@ -300,7 +300,7 @@ def test_shifter():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.shift(0x50, preserve_regs=['ebx'])
@@ -326,7 +326,7 @@ def test_shifter():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.shift(0x40)
@@ -341,7 +341,7 @@ def test_shifter():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.shift(0x40)
@@ -357,7 +357,7 @@ def test_shifter():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.shift(0x10)
@@ -374,7 +374,7 @@ def test_retsled():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.retsled(0x40)
@@ -388,7 +388,7 @@ def test_retsled():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.retsled(0x40)
@@ -401,7 +401,7 @@ def test_retsled():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.retsled(0x40)
@@ -435,7 +435,7 @@ def test_retn_i386_call_chain():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     # force to use 'retn 0xc' to clean up function arguments
@@ -600,7 +600,7 @@ def test_graph_search_reg_setter():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     # the easy peasy pop-only reg setter
@@ -1122,7 +1122,7 @@ def test_riscv_oop_normalization():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets(processes=16, optimize=False)
+        rop.find_gadgets_single_threaded(optimize=False)
         rop.save_gadgets(cache_path)
 
     g = rop.analyze_gadget(0x00000000000407cc)
@@ -1163,7 +1163,7 @@ def test_mem_changer():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
 
     # xor
     chain = rop.write_to_mem(0xdeadbeef, b'\x63')

--- a/tests/test_gadgets.py
+++ b/tests/test_gadgets.py
@@ -650,7 +650,7 @@ def test_concrete_reg_change():
     g = rop.analyze_gadget(0)
     assert g.concrete_reg_changes and 'rax' in g.concrete_reg_changes
     init_ast, final_ast = g.concrete_reg_changes['rax']
-    new_ast = claripy.algorithm.replace(expr=final_ast, old=init_ast, new=claripy.BVV(1, 64))
+    new_ast = claripy.replace(expr=final_ast, old=init_ast, new=claripy.BVV(1, 64))
     assert new_ast.concrete_value == 0x42
 
     # the other side must be concrete

--- a/tests/test_gadgets.py
+++ b/tests/test_gadgets.py
@@ -1,6 +1,6 @@
 import os
 
-import claripy
+from angr import claripy
 import angr
 import angrop # pylint: disable=unused-import
 from angrop.rop_gadget import RopGadget, PivotGadget, SyscallGadget

--- a/tests/test_gadgets.py
+++ b/tests/test_gadgets.py
@@ -15,7 +15,7 @@ def get_rop(path):
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
     return rop
 

--- a/tests/test_rop.py
+++ b/tests/test_rop.py
@@ -265,7 +265,7 @@ def test_roptest_aarch64():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.write_to_mem(0x41414140, b'AAAAAAA')
@@ -285,7 +285,7 @@ def test_acct_sa():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.set_regs(rax=0x41414141)
@@ -314,7 +314,7 @@ def test_liblog():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     chain = rop.set_regs(rdx=0x41414141)

--- a/tests/test_rop.py
+++ b/tests/test_rop.py
@@ -2,7 +2,7 @@ import os
 import pickle
 import logging
 
-import claripy
+from angr import claripy
 import angr
 import angrop  # pylint: disable=unused-import
 

--- a/tests/test_ropblock.py
+++ b/tests/test_ropblock.py
@@ -107,7 +107,7 @@ def test_stack_offset_infinite_loop():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets(optimize=False)
+        rop.find_gadgets_single_threaded(optimize=False)
         rop.save_gadgets(cache_path)
 
     addrs = [g.addr for g in rop._all_gadgets]
@@ -127,7 +127,7 @@ def test_normalized_block_effect2():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets(processes=16, optimize=False)
+        rop.find_gadgets_single_threaded(optimize=False)
         rop.save_gadgets(cache_path)
 
     gs = rop.analyze_addr(0x4ae6)
@@ -159,7 +159,7 @@ def test_jmp_reg_normalize_fast_path():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path, optimize=False)
     else:
-        rop.find_gadgets(processes=16, optimize=False)
+        rop.find_gadgets_single_threaded(optimize=False)
         rop.save_gadgets(cache_path)
 
     rop.optimize(processes=1)

--- a/tests/test_ropchain.py
+++ b/tests/test_ropchain.py
@@ -18,7 +18,7 @@ def test_chain_exec():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     # make sure the target gadget exist
@@ -45,7 +45,7 @@ def test_sigreturn_chain_i386():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.set_roparg_filler(0)
@@ -79,7 +79,7 @@ def test_sigreturn_chain_amd64():
     if os.path.exists(cache_path):
         rop.load_gadgets(cache_path)
     else:
-        rop.find_gadgets()
+        rop.find_gadgets_single_threaded()
         rop.save_gadgets(cache_path)
 
     rop.set_roparg_filler(0)


### PR DESCRIPTION
Depends on angr/angr#6550, which merges claripy (clarirs) into the angr package: claripy is no longer importable as a standalone top-level module — it lives at `angr.rustylib.claripy` and is exposed as `angr.claripy`.

This PR rewrites every `import claripy` to `from angr import claripy` so angrop keeps working with that change (11 files, mechanical; the bound name stays `claripy` so no call sites change).

Linked PRs (for angr CI cross-checkout):
- https://github.com/angr/angr/pull/6550
- https://github.com/angr/rex/pull/123
- https://github.com/angr/binaries/pull/168
- https://github.com/angr/angr-examples/pull/14
- https://github.com/mechaphish/colorguard/pull/14